### PR TITLE
[NONEVM-1988] fix .gitignore chainlink-ton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@ docs/local/**
 node_modules/
 
 # Go build artifacts
-chainlink-ton
+/chainlink-ton
 
 # macOS Finder metadata
 .DS_Store


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/NONEVM-1988

.gitignore was excluding all files and directories named `chainlink-ton` instead of just root level directory