### PR TITLE
Clean up unused docker images for CTF, update gitignore

### DIFF
--- a/.github/workflows/ccip-integration-test.yml
+++ b/.github/workflows/ccip-integration-test.yml
@@ -14,13 +14,9 @@ env:
   DOCKER_CACHE_KEY: ccip-e2e-images-v0
   DOCKER_CACHE_DIR: ${{ github.workspace }}/.cache
   DOCKER_CACHE_TAR_NAME: ccip-e2e-docker-images.tar
-  # TON localnet(mylocalton) docker images & CCIP E2E test database image
+  # mylocalton docker image / CCIP E2E test database image
   DOCKER_IMAGES: >-
     ghcr.io/neodix42/mylocalton-docker:latest
-    redis:latest
-    postgres:17
-    ghcr.io/neodix42/ton-http-api:latest
-    ghcr.io/neodix42/mylocalton-docker-faucet:latest
     postgres:14-alpine
 jobs:
   prepare-images:

--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,4 @@ node_modules/
 .DS_Store
 
 # Golangci-lint reports
-golangci-lint-relay-report.xml
-golangci-lint-integration-tests-report.xml
+golangci-lint-*-report.xml


### PR DESCRIPTION
Follow up cleaning of https://github.com/smartcontractkit/chainlink-ton/pull/54 and https://github.com/smartcontractkit/chainlink-testing-framework/pull/1937