### PR TITLE
fix: golangcilint report path

### DIFF
--- a/integration-tests/smoke/logpoller/log_poller_test.go
+++ b/integration-tests/smoke/logpoller/log_poller_test.go
@@ -24,12 +24,10 @@ import (
 )
 
 func Test_LogPoller(t *testing.T) {
-
 	client := test_utils.CreateAPIClient(t, chainsel.TON_LOCALNET.Selector).WithRetry()
 	require.NotNil(t, client)
 
 	t.Run("log poller:log collector event ingestion", func(t *testing.T) {
-
 		t.Parallel()
 		// test event source config
 		const batchCount = 3

--- a/pkg/logpoller/log_poller.go
+++ b/pkg/logpoller/log_poller.go
@@ -1,17 +1,18 @@
 package logpoller
 
 import (
-	"github.com/smartcontractkit/chainlink-ton/pkg/ton/event"
 	"context"
 	"fmt"
 	"time"
 
 	"github.com/xssnick/tonutils-go/address"
+	"github.com/xssnick/tonutils-go/ton"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-	"github.com/xssnick/tonutils-go/ton"
-	"github.com/smartcontractkit/chainlink-ton/pkg/logpoller/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
+
+	"github.com/smartcontractkit/chainlink-ton/pkg/logpoller/types"
+	"github.com/smartcontractkit/chainlink-ton/pkg/ton/event"
 )
 
 // TON LogPoller Service - CCIP MVP Implementation


### PR DESCRIPTION
This PR fixes wrong golang-ci report path 
Corrected behavior: https://github.com/smartcontractkit/chainlink-ton/actions/runs/16830085864/job/47675421226?pr=97


```sh
# Run if [ -f "pkg/golangci-lint-pkg-report.xml" ]; then
<?xml version="1.0" encoding="UTF-8"?>

<checkstyle version="5.0">
  <file name="pkg/logpoller/log_poller.go">
    <error column="1" line="4" message="File is not properly formatted" severity="error" source="goimports"></error>
  </file>
</checkstyle>
1s
```

```sh
# Run actions/upload-artifact@v4
With the provided path, there will be 1 file uploaded
Artifact name is valid!
Root directory input is valid!
Beginning upload of artifact content to blob storage
Uploaded bytes 350
Finished uploading artifact content to blob storage!
SHA256 digest of uploaded artifact zip is 04fd16d0904c3b324438d08e7d1c49b1ec011e456e25a39359996f50853738e9
Finalizing artifact upload
Artifact pkg-lint-report.zip successfully finalized. Artifact ID 3719387616
Artifact pkg-lint-report has been successfully uploaded! Final size is 350 bytes. Artifact ID is 3719387616
Artifact download URL: https://github.com/smartcontractkit/chainlink-ton/actions/runs/16830085864/artifacts/3719387616
```
```