### PR TITLE
Pin previous version of mylocalton-docker(3.4)

### DIFF
--- a/integration-tests/utils/chain.go
+++ b/integration-tests/utils/chain.go
@@ -219,7 +219,7 @@ func createNewNetwork(t *testing.T, chainID uint64) string {
 		Port:    strconv.Itoa(port),
 		// Note(@jadepark-dev): Due to mylocalton-docker 3.5 update, file server(for fetching config) service has been separated.
 		// https://github.com/neodix42/mylocalton-docker/pkgs/container/mylocalton-docker/versions
-		// This is older version(3.4) hash, ideally we should have automatic PR that watch releases, updates version, and run CI tests
+		// This is older version(3.4) hash, ideally we should have automatic PR that watches releases, updates version, and run CI tests
 		Image: "ghcr.io/neodix42/mylocalton-docker@sha256:b4a8dc4bdd01a9bb5ebbe817ef764b9a21f2769b660b31733f7477b203d342ce",
 		CustomEnv: map[string]string{
 			"VERSION_CAPABILITIES":        "11",


### PR DESCRIPTION
This PR pins mylocalton-docker to version 3.4 to resolve compatibility issues

* Pinned mylocalton-docker image to version 3.4 using specific SHA hash to avoid breaking changes from v3.5 update
* Temporary workaround until CTFv2 is updated to support the new file server service architecture introduced in v3.5

Note: This is a temporary fix. The v3.5 update separated the file server service used for fetching network configuration, which requires CTFv2 updates to be revisited in a future PR.