### PR TITLE
[NONEVM-2406] [mcms] Cleanup multisig test suite

### DIFF
--- a/contracts/src/utils/dict.ts
+++ b/contracts/src/utils/dict.ts
@@ -11,3 +11,13 @@ export const loadMap = <K extends DictionaryKeyTypes, V>(
   }
   return dict
 }
+
+export function loadDict<K extends DictionaryKeyTypes, V>(dict: Dictionary<K, V>): Map<K, V> {
+  const map: Map<K, V> = new Map()
+
+  for (const [key, value] of dict) {
+    map.set(key, value)
+  }
+
+  return map
+}

--- a/contracts/tests/lib/access/Ownable2Step.spec.ts
+++ b/contracts/tests/lib/access/Ownable2Step.spec.ts
@@ -3,12 +3,8 @@ import { Blockchain, SandboxContract, TreasuryContract } from '@ton/sandbox'
 import { toNano } from '@ton/core'
 import { compile } from '@ton/blueprint'
 
-import * as ownable2step from '../../../wrappers/libraries/access/Ownable2Step'
+import * as ownable2Step from '../../../wrappers/libraries/access/Ownable2Step'
 import * as counter from '../../../wrappers/examples/Counter'
-
-const ERROR_ONLY_CALLABLE_BY_OWNER = 132
-const ERROR_CANNOT_TRANSFER_TO_SELF = 1001
-const ERROR_MUST_BE_PROPOSED_OWNER = 1002
 
 describe('Ownable2Step Counter', () => {
   let blockchain: Blockchain
@@ -16,7 +12,7 @@ describe('Ownable2Step Counter', () => {
 
   let bind: {
     counter: SandboxContract<counter.ContractClient>
-    ownable: SandboxContract<ownable2step.ContractClient>
+    ownable: SandboxContract<ownable2Step.ContractClient>
   } = {
     counter: null as any,
     ownable: null as any,
@@ -37,7 +33,7 @@ describe('Ownable2Step Counter', () => {
     }
 
     bind.counter = blockchain.openContract(counter.ContractClient.newFrom(data, code))
-    bind.ownable = blockchain.openContract(ownable2step.ContractClient.newAt(bind.counter.address))
+    bind.ownable = blockchain.openContract(ownable2Step.ContractClient.newAt(bind.counter.address))
 
     const deployResult = await bind.counter.sendDeploy(deployer.getSender(), toNano('0.05'))
 
@@ -86,7 +82,7 @@ describe('Ownable2Step Counter', () => {
     expect(result.transactions).toHaveTransaction({
       from: other.address,
       to: bind.counter.address,
-      exitCode: ERROR_ONLY_CALLABLE_BY_OWNER,
+      exitCode: ownable2Step.Errors.OnlyCallableByOwner,
       success: false,
     })
 
@@ -127,7 +123,7 @@ describe('Ownable2Step Counter', () => {
     expect(resultSetCount.transactions).toHaveTransaction({
       from: other.address,
       to: bind.counter.address,
-      exitCode: ERROR_ONLY_CALLABLE_BY_OWNER,
+      exitCode: ownable2Step.Errors.OnlyCallableByOwner,
       success: false,
     })
 
@@ -197,7 +193,7 @@ describe('Ownable2Step Counter', () => {
     expect(resultSetCount.transactions).toHaveTransaction({
       from: owner.address,
       to: bind.counter.address,
-      exitCode: ERROR_ONLY_CALLABLE_BY_OWNER,
+      exitCode: ownable2Step.Errors.OnlyCallableByOwner,
       success: false,
     })
   })
@@ -210,7 +206,7 @@ describe('Ownable2Step Counter', () => {
     expect(result.transactions).toHaveTransaction({
       from: other.address,
       to: bind.counter.address,
-      exitCode: ERROR_MUST_BE_PROPOSED_OWNER,
+      exitCode: ownable2Step.Errors.MustBeProposedOwner,
       success: false,
     })
   })
@@ -231,7 +227,7 @@ describe('Ownable2Step Counter', () => {
     expect(result.transactions).toHaveTransaction({
       from: other.address,
       to: bind.counter.address,
-      exitCode: ERROR_MUST_BE_PROPOSED_OWNER,
+      exitCode: ownable2Step.Errors.MustBeProposedOwner,
       success: false,
     })
   })
@@ -245,7 +241,7 @@ describe('Ownable2Step Counter', () => {
     expect(result.transactions).toHaveTransaction({
       from: other.address,
       to: bind.ownable.address,
-      exitCode: ERROR_ONLY_CALLABLE_BY_OWNER,
+      exitCode: ownable2Step.Errors.OnlyCallableByOwner,
       success: false,
     })
   })
@@ -259,7 +255,7 @@ describe('Ownable2Step Counter', () => {
     expect(result.transactions).toHaveTransaction({
       from: owner.address,
       to: bind.ownable.address,
-      exitCode: ERROR_CANNOT_TRANSFER_TO_SELF,
+      exitCode: ownable2Step.Errors.CannotTransferToSelf,
       success: false,
     })
   })

--- a/contracts/tests/mcms/BaseTest.ts
+++ b/contracts/tests/mcms/BaseTest.ts
@@ -237,16 +237,24 @@ export class BaseTestSetup {
     expect(await this.bind.ac.getRoleAdmin(rbactl.roles.admin)).toEqual(rbactl.roles.admin)
   }
 
-  // TODO
-  // deployCallProxyContract() {
-  //   const body = callproxy.builder.message.in.topUp.encode({ queryId: 1n })
-  //   return this.bind.callProxy.sendInternal(this.acc.deployer.getSender(), toNano('0.05'), body)
-  // }
-
-  deployCounterContract() {
+  /**
+   * Deploy the counter contract and verify deployment
+   */
+  async deployCounterContract() {
     // const body = counter.builder.message.in.topUp.encode({ queryId: 1n }) // TODO use TopUp after it is implemented
     const body = beginCell().endCell()
-    return this.bind.counter.sendInternal(this.acc.deployer.getSender(), toNano('0.05'), body)
+    const result = await this.bind.counter.sendInternal(
+      this.acc.deployer.getSender(),
+      toNano('0.05'),
+      body,
+    )
+
+    expect(result.transactions).toHaveTransaction({
+      from: this.acc.deployer.address,
+      to: this.bind.counter.address,
+      deploy: true,
+      success: true,
+    })
   }
 
   /**
@@ -257,7 +265,6 @@ export class BaseTestSetup {
     await this.setupTimelockContract(testId)
     await this.deployTimelockContract()
     await this.setupCallProxyContract(testId)
-    // await this.deployCallProxyContract()
     await this.setupCounterContract(testId)
     await this.deployCounterContract()
   }

--- a/contracts/tests/mcms/BaseTest.ts
+++ b/contracts/tests/mcms/BaseTest.ts
@@ -241,7 +241,7 @@ export class BaseTestSetup {
    * Deploy the callProxy contract and verify deployment
    */
   async deployCallProxyContract() {
-    const body = beginCell().endCell()
+    const body = beginCell().endCell() // TODO change for TopUp msg
     const result = await this.bind.callProxy.sendInternal(
       this.acc.deployer.getSender(),
       toNano('0.05'),
@@ -250,7 +250,7 @@ export class BaseTestSetup {
 
     expect(result.transactions).toHaveTransaction({
       from: this.acc.deployer.address,
-      to: this.bind.counter.address,
+      to: this.bind.callProxy.address,
       deploy: true,
       success: true,
     })
@@ -304,10 +304,10 @@ export class BaseTestSetup {
     await this.initializeBlockchain()
     await this.setupTimelockContract(testId)
     await this.deployTimelockContract()
-    await this.setupCallProxyContract(testId)
-    await this.deployCallProxyContract()
     await this.setupCounterContract(testId)
     await this.deployCounterContract()
+    await this.setupCallProxyContract(testId)
+    await this.deployCallProxyContract()
   }
 
   /**

--- a/contracts/tests/mcms/BaseTest.ts
+++ b/contracts/tests/mcms/BaseTest.ts
@@ -1,17 +1,15 @@
 import '@ton/test-utils'
 
 import { Blockchain, SandboxContract, TreasuryContract } from '@ton/sandbox'
-import { Address, Cell, Dictionary, toNano, beginCell } from '@ton/core'
+import { Cell, toNano, beginCell } from '@ton/core'
 import { compile } from '@ton/blueprint'
 
 import { asSnakeData } from '../../src/utils'
 
-import { mcms } from '../../wrappers/mcms'
 import { rbactl } from '../../wrappers/mcms'
 import { callproxy } from '../../wrappers/mcms'
 import { ac } from '../../wrappers/lib/access'
 import * as counter from '../../wrappers/examples/Counter'
-import * as ownable2step from '../../wrappers/libraries/access/Ownable2Step'
 
 import { crc32 } from 'zlib'
 

--- a/contracts/tests/mcms/BaseTest.ts
+++ b/contracts/tests/mcms/BaseTest.ts
@@ -15,14 +15,14 @@ import * as ownable2step from '../../wrappers/libraries/access/Ownable2Step'
 
 import { crc32 } from 'zlib'
 
-export interface TestCode {
+export type TestCode = {
   mcms: Cell
   timelock: Cell
   callProxy: Cell
   counter: Cell
 }
 
-export interface TestAccounts {
+export type TestAccounts = {
   deployer: SandboxContract<TreasuryContract>
   admin: SandboxContract<TreasuryContract>
   proposerOne: SandboxContract<TreasuryContract>
@@ -35,7 +35,7 @@ export interface TestAccounts {
   bypasserTwo: SandboxContract<TreasuryContract>
 }
 
-export interface TestContracts {
+export type TestContracts = {
   timelock: SandboxContract<rbactl.ContractClient>
   ac: SandboxContract<ac.ContractClient>
   callProxy: SandboxContract<callproxy.ContractClient>

--- a/contracts/tests/mcms/BaseTest.ts
+++ b/contracts/tests/mcms/BaseTest.ts
@@ -238,6 +238,25 @@ export class BaseTestSetup {
   }
 
   /**
+   * Deploy the callProxy contract and verify deployment
+   */
+  async deployCallProxyContract() {
+    const body = beginCell().endCell()
+    const result = await this.bind.callProxy.sendInternal(
+      this.acc.deployer.getSender(),
+      toNano('0.05'),
+      body,
+    )
+
+    expect(result.transactions).toHaveTransaction({
+      from: this.acc.deployer.address,
+      to: this.bind.counter.address,
+      deploy: true,
+      success: true,
+    })
+  }
+
+  /**
    * Deploy the counter contract and verify deployment
    */
   async deployCounterContract() {
@@ -258,6 +277,27 @@ export class BaseTestSetup {
   }
 
   /**
+   * Grant the call proxy executor role to the call proxy contract
+   */
+  async grantCallProxyExecutorRole() {
+    const body = ac.builder.message.in.grantRole.encode({
+      queryId: 1n,
+      role: rbactl.roles.executor,
+      account: this.bind.callProxy.address,
+    })
+    const result = await this.bind.timelock.sendInternal(
+      this.acc.admin.getSender(),
+      toNano('0.05'),
+      body,
+    )
+    expect(result.transactions).toHaveTransaction({
+      from: this.acc.admin.address,
+      to: this.bind.timelock.address,
+      success: true,
+    })
+  }
+
+  /**
    * Complete setup for all contracts - convenience method that combines all setup steps
    */
   async setupAll(testId: string): Promise<void> {
@@ -265,6 +305,7 @@ export class BaseTestSetup {
     await this.setupTimelockContract(testId)
     await this.deployTimelockContract()
     await this.setupCallProxyContract(testId)
+    await this.deployCallProxyContract()
     await this.setupCounterContract(testId)
     await this.deployCounterContract()
   }

--- a/contracts/tests/mcms/Integration.spec.ts
+++ b/contracts/tests/mcms/Integration.spec.ts
@@ -1,12 +1,11 @@
 import '@ton/test-utils'
 
 import { Blockchain, SandboxContract, TreasuryContract } from '@ton/sandbox'
-import { Address, beginCell, Cell, Dictionary, toNano } from '@ton/core'
+import { Address, beginCell, Cell, toNano } from '@ton/core'
 import { KeyPair, sign } from '@ton/crypto'
 import { compile } from '@ton/blueprint'
 
 import { asSnakeData, uint8ArrayToBigInt } from '../../src/utils'
-import { loadMap } from '../../src/utils/dict'
 import { generateEd25519KeyPair } from '../libraries/ocr/Helpers'
 
 import { mcms } from '../../wrappers/mcms'
@@ -257,26 +256,13 @@ describe('MCMS - IntegrationTest', () => {
         toNano('0.2'),
         mcms.builder.message.in.setConfig.encode({
           queryId: 1n,
-          signerKeys: asSnakeData<bigint>(
-            proposerKeyPairs().map((v) => uint8ArrayToBigInt(v.publicKey)),
-            (v) => beginCell().storeUint(v, 256),
+          signerKeys: proposerKeyPairs().map((v) => uint8ArrayToBigInt(v.publicKey)),
+          signerGroups: Array(PROPOSE_COUNT).fill(0),
+          groupQuorums: new Map(Array.from({ length: MCMS_NUM_GROUPS }, (_, i) => [i, 0])).set(
+            0,
+            PROPOSE_QUORUM,
           ),
-          signerGroups: asSnakeData<number>(Array(PROPOSE_COUNT).fill(0), (v) =>
-            beginCell().storeUint(v, 8),
-          ),
-          groupQuorums: loadMap(
-            Dictionary.Keys.Uint(8),
-            Dictionary.Values.Uint(8),
-            new Map(Array.from({ length: MCMS_NUM_GROUPS }, (_, i) => [i, 0])).set(
-              0,
-              PROPOSE_QUORUM,
-            ),
-          ),
-          groupParents: loadMap(
-            Dictionary.Keys.Uint(8),
-            Dictionary.Values.Uint(8),
-            new Map(Array.from({ length: MCMS_NUM_GROUPS }, (_, i) => [i, 0])),
-          ),
+          groupParents: new Map(Array.from({ length: MCMS_NUM_GROUPS }, (_, i) => [i, 0])),
           clearRoot: false,
         }),
       )
@@ -314,23 +300,14 @@ describe('MCMS - IntegrationTest', () => {
         toNano('0.2'),
         mcms.builder.message.in.setConfig.encode({
           queryId: 1n,
-          signerKeys: asSnakeData<bigint>(
-            vetoKeyPairs().map((v) => uint8ArrayToBigInt(v.publicKey)),
-            (v) => beginCell().storeUint(v, 256),
+          signerKeys: vetoKeyPairs().map((v) => uint8ArrayToBigInt(v.publicKey)),
+          signerGroups: Array(VETO_COUNT).fill(0),
+          groupQuorums: new Map(Array.from({ length: MCMS_NUM_GROUPS }, (_, i) => [i, 0])).set(
+            0,
+            VETO_QUORUM,
           ),
-          signerGroups: asSnakeData<number>(Array(VETO_COUNT).fill(0), (v) =>
-            beginCell().storeUint(v, 8),
-          ),
-          groupQuorums: loadMap(
-            Dictionary.Keys.Uint(8),
-            Dictionary.Values.Uint(8),
-            new Map(Array.from({ length: MCMS_NUM_GROUPS }, (_, i) => [i, 0])).set(0, VETO_QUORUM),
-          ),
-          groupParents: loadMap(
-            Dictionary.Keys.Uint(8),
-            Dictionary.Values.Uint(8),
-            new Map(Array.from({ length: MCMS_NUM_GROUPS }, (_, i) => [i, 0])),
-          ),
+
+          groupParents: new Map(Array.from({ length: MCMS_NUM_GROUPS }, (_, i) => [i, 0])),
           clearRoot: false,
         }),
       )
@@ -368,32 +345,18 @@ describe('MCMS - IntegrationTest', () => {
         toNano('0.2'),
         mcms.builder.message.in.setConfig.encode({
           queryId: 1n,
-          signerKeys: asSnakeData<bigint>(
-            signerKeyPairs.map((v) => uint8ArrayToBigInt(v.publicKey)),
-            (v) => beginCell().storeUint(v, 256),
-          ),
-          signerGroups: asSnakeData<number>(
-            Array(PROPOSE_COUNT + VETO_COUNT)
-              .fill(1, 0, PROPOSE_COUNT)
-              .fill(2, PROPOSE_COUNT, PROPOSE_COUNT + VETO_COUNT),
-            (v) => beginCell().storeUint(v, 8),
-          ),
-          groupQuorums: loadMap(
-            Dictionary.Keys.Uint(8),
-            Dictionary.Values.Uint(8),
-            new Map(Array.from({ length: MCMS_NUM_GROUPS }, (_, i) => [i, 0]))
-              .set(0, 2)
-              .set(1, PROPOSE_QUORUM)
-              .set(2, VETO_QUORUM),
-          ),
-          groupParents: loadMap(
-            Dictionary.Keys.Uint(8),
-            Dictionary.Values.Uint(8),
-            new Map(Array.from({ length: MCMS_NUM_GROUPS }, (_, i) => [i, 0]))
-              .set(0, 0)
-              .set(1, 0)
-              .set(2, 0),
-          ),
+          signerKeys: signerKeyPairs.map((v) => uint8ArrayToBigInt(v.publicKey)),
+          signerGroups: Array(PROPOSE_COUNT + VETO_COUNT)
+            .fill(1, 0, PROPOSE_COUNT)
+            .fill(2, PROPOSE_COUNT, PROPOSE_COUNT + VETO_COUNT),
+          groupQuorums: new Map(Array.from({ length: MCMS_NUM_GROUPS }, (_, i) => [i, 0]))
+            .set(0, 2)
+            .set(1, PROPOSE_QUORUM)
+            .set(2, VETO_QUORUM),
+          groupParents: new Map(Array.from({ length: MCMS_NUM_GROUPS }, (_, i) => [i, 0]))
+            .set(0, 0)
+            .set(1, 0)
+            .set(2, 0),
           clearRoot: false,
         }),
       )
@@ -1108,26 +1071,13 @@ describe('MCMS - IntegrationTest', () => {
             value: toNano('0.2'),
             data: mcms.builder.message.in.setConfig.encode({
               queryId: 1n,
-              signerKeys: asSnakeData<bigint>(
-                proposerKeyPairs().map((v) => uint8ArrayToBigInt(v.publicKey)),
-                (v) => beginCell().storeUint(v, 256),
+              signerKeys: proposerKeyPairs().map((v) => uint8ArrayToBigInt(v.publicKey)),
+              signerGroups: Array(PROPOSE_COUNT).fill(0),
+              groupQuorums: new Map(Array.from({ length: MCMS_NUM_GROUPS }, (_, i) => [i, 0])).set(
+                0,
+                PROPOSE_QUORUM - 1,
               ),
-              signerGroups: asSnakeData<number>(Array(PROPOSE_COUNT).fill(0), (v) =>
-                beginCell().storeUint(v, 8),
-              ),
-              groupQuorums: loadMap(
-                Dictionary.Keys.Uint(8),
-                Dictionary.Values.Uint(8),
-                new Map(Array.from({ length: MCMS_NUM_GROUPS }, (_, i) => [i, 0])).set(
-                  0,
-                  PROPOSE_QUORUM - 1,
-                ),
-              ),
-              groupParents: loadMap(
-                Dictionary.Keys.Uint(8),
-                Dictionary.Values.Uint(8),
-                new Map(Array.from({ length: MCMS_NUM_GROUPS }, (_, i) => [i, 0])),
-              ),
+              groupParents: new Map(Array.from({ length: MCMS_NUM_GROUPS }, (_, i) => [i, 0])),
               clearRoot: false,
             }),
           },
@@ -1136,26 +1086,13 @@ describe('MCMS - IntegrationTest', () => {
             value: toNano('0.2'),
             data: mcms.builder.message.in.setConfig.encode({
               queryId: 1n,
-              signerKeys: asSnakeData<bigint>(
-                vetoKeyPairs().map((v) => uint8ArrayToBigInt(v.publicKey)),
-                (v) => beginCell().storeUint(v, 256),
+              signerKeys: vetoKeyPairs().map((v) => uint8ArrayToBigInt(v.publicKey)),
+              signerGroups: Array(VETO_COUNT).fill(0),
+              groupQuorums: new Map(Array.from({ length: MCMS_NUM_GROUPS }, (_, i) => [i, 0])).set(
+                0,
+                VETO_QUORUM - 1,
               ),
-              signerGroups: asSnakeData<number>(Array(VETO_COUNT).fill(0), (v) =>
-                beginCell().storeUint(v, 8),
-              ),
-              groupQuorums: loadMap(
-                Dictionary.Keys.Uint(8),
-                Dictionary.Values.Uint(8),
-                new Map(Array.from({ length: MCMS_NUM_GROUPS }, (_, i) => [i, 0])).set(
-                  0,
-                  VETO_QUORUM - 1,
-                ),
-              ),
-              groupParents: loadMap(
-                Dictionary.Keys.Uint(8),
-                Dictionary.Values.Uint(8),
-                new Map(Array.from({ length: MCMS_NUM_GROUPS }, (_, i) => [i, 0])),
-              ),
+              groupParents: new Map(Array.from({ length: MCMS_NUM_GROUPS }, (_, i) => [i, 0])),
               clearRoot: false,
             }),
           },

--- a/contracts/tests/mcms/Integration.spec.ts
+++ b/contracts/tests/mcms/Integration.spec.ts
@@ -567,16 +567,13 @@ describe('MCMS - IntegrationTest', () => {
         success: true,
       })
 
-      // TODO: move this encoding internally to lib
-      const encodeProof = (v) => beginCell().storeUint(v, 256)
-
       const r1 = await bind.mcmsPropose.sendInternal(
         acc.deployer.getSender(),
         toNano('0.10'),
         mcms.builder.message.in.execute.encode({
           queryId: 1n,
           op: mcms.builder.data.op.encode(ops[0]),
-          proof: asSnakeData<bigint>(opProofs[0], encodeProof),
+          proof: opProofs[0],
         }),
       )
 
@@ -689,16 +686,13 @@ describe('MCMS - IntegrationTest', () => {
         success: true,
       })
 
-      // TODO: move this encoding internally to lib
-      const encodeProof = (v) => beginCell().storeUint(v, 256)
-
       const r1 = await bind.mcmsPropose.sendInternal(
         acc.deployer.getSender(),
         toNano('0.10'),
         mcms.builder.message.in.execute.encode({
           queryId: 1n,
           op: mcms.builder.data.op.encode(ops[0]),
-          proof: asSnakeData<bigint>(opProofs[0], encodeProof),
+          proof: opProofs[0],
         }),
       )
 
@@ -817,16 +811,13 @@ describe('MCMS - IntegrationTest', () => {
         success: true,
       })
 
-      // TODO: move this encoding internally to lib
-      const encodeProof = (v) => beginCell().storeUint(v, 256)
-
       const r1 = await bind.mcmsBypass.sendInternal(
         acc.deployer.getSender(),
         toNano('0.10'),
         mcms.builder.message.in.execute.encode({
           queryId: 1n,
           op: mcms.builder.data.op.encode(ops[0]),
-          proof: asSnakeData<bigint>(opProofs[0], encodeProof),
+          proof: opProofs[0],
         }),
       )
 
@@ -939,16 +930,13 @@ describe('MCMS - IntegrationTest', () => {
         success: true,
       })
 
-      // TODO: move this encoding internally to lib
-      const encodeProof = (v) => beginCell().storeUint(v, 256)
-
       const r1 = await bind.mcmsPropose.sendInternal(
         acc.deployer.getSender(),
         toNano('0.10'),
         mcms.builder.message.in.execute.encode({
           queryId: 1n,
           op: mcms.builder.data.op.encode(ops[0]),
-          proof: asSnakeData<bigint>(opProofs[0], encodeProof),
+          proof: opProofs[0],
         }),
       )
 
@@ -1016,16 +1004,13 @@ describe('MCMS - IntegrationTest', () => {
           success: true,
         })
 
-        // TODO: move this encoding internally to lib
-        const encodeProof = (v) => beginCell().storeUint(v, 256)
-
         const r1 = await bind.mcmsVeto.sendInternal(
           acc.deployer.getSender(),
           toNano('0.10'),
           mcms.builder.message.in.execute.encode({
             queryId: 1n,
             op: mcms.builder.data.op.encode(ops[0]),
-            proof: asSnakeData<bigint>(opProofs[0], encodeProof),
+            proof: opProofs[0],
           }),
         )
 
@@ -1150,16 +1135,13 @@ describe('MCMS - IntegrationTest', () => {
         success: true,
       })
 
-      // TODO: move this encoding internally to lib
-      const encodeProof = (v) => beginCell().storeUint(v, 256)
-
       const r1 = await bind.mcmsPropose.sendInternal(
         acc.deployer.getSender(),
         toNano('0.10'),
         mcms.builder.message.in.execute.encode({
           queryId: 1n,
           op: mcms.builder.data.op.encode(ops[0]),
-          proof: asSnakeData<bigint>(opProofs[0], encodeProof),
+          proof: opProofs[0],
         }),
       )
 

--- a/contracts/tests/mcms/MCMS.spec.ts
+++ b/contracts/tests/mcms/MCMS.spec.ts
@@ -1,7 +1,7 @@
 import '@ton/test-utils'
 
 import { Blockchain, SandboxContract, TreasuryContract } from '@ton/sandbox'
-import { Cell, Dictionary, toNano } from '@ton/core'
+import { Cell, toNano } from '@ton/core'
 import { compile } from '@ton/blueprint'
 
 import { mcms } from '../../wrappers/mcms'

--- a/contracts/tests/mcms/ManyChainMultiSigBaseTest.ts
+++ b/contracts/tests/mcms/ManyChainMultiSigBaseTest.ts
@@ -532,7 +532,8 @@ export class MCMSBaseSetRootAndExecuteTestSetup extends MCMSBaseTestSetup {
     return this.opProofs[opIndex]
   }
 
-  async advanceOpcodeTo(index: number) {
+  // Execute all operations up to the post-op count limit to simulate setOpCount
+  async executeOperationsUpTo(index: number) {
     for (let i = 0; i < index; i++) {
       const executeBody = mcms.builder.message.in.execute.encode({
         queryId: BigInt(i + 1),

--- a/contracts/tests/mcms/ManyChainMultiSigBaseTest.ts
+++ b/contracts/tests/mcms/ManyChainMultiSigBaseTest.ts
@@ -35,7 +35,7 @@ export type MCMSTestContracts = {
 export type TestSigner = {
   address: Address
   keyPair: KeyPair
-  treasury: SandboxContract<TreasuryContract>
+  wallet: SandboxContract<TreasuryContract>
   index: number
   group: number
 }
@@ -121,7 +121,7 @@ export class MCMSBaseTestSetup {
       signers.push({
         address,
         keyPair: keyPairs[i],
-        treasury: this.acc.signers[i],
+        wallet: this.acc.signers[i],
         index: i,
         group,
       })

--- a/contracts/tests/mcms/ManyChainMultiSigBaseTest.ts
+++ b/contracts/tests/mcms/ManyChainMultiSigBaseTest.ts
@@ -15,24 +15,24 @@ import { crc32 } from 'zlib'
 import { asSnakeData, uint8ArrayToBigInt } from '../../src/utils'
 import { generateEd25519KeyPair } from '../libraries/ocr/Helpers'
 
-export interface MCMSTestCode {
+export type MCMSTestCode = {
   mcms: Cell
   counter: Cell
 }
 
-export interface MCMSTestAccounts {
+export type MCMSTestAccounts = {
   deployer: SandboxContract<TreasuryContract>
   multisigOwner: SandboxContract<TreasuryContract>
   // 9 signers with their private keys
   signers: SandboxContract<TreasuryContract>[]
 }
 
-export interface MCMSTestContracts {
+export type MCMSTestContracts = {
   mcms: SandboxContract<mcms.ContractClient>
   counter: SandboxContract<counter.ContractClient>
 }
 
-export interface TestSigner {
+export type TestSigner = {
   address: Address
   keyPair: KeyPair
   treasury: SandboxContract<TreasuryContract>

--- a/contracts/tests/mcms/ManyChainMultiSigBaseTest.ts
+++ b/contracts/tests/mcms/ManyChainMultiSigBaseTest.ts
@@ -534,13 +534,10 @@ export class MCMSBaseSetRootAndExecuteTestSetup extends MCMSBaseTestSetup {
 
   async advanceOpcodeTo(index: number) {
     for (let i = 0; i < index; i++) {
-      const proof = this.opProofs[i]
-      const proofCell = asSnakeData<bigint>(proof, (v) => beginCell().storeUint(v, 256))
-
       const executeBody = mcms.builder.message.in.execute.encode({
         queryId: BigInt(i + 1),
         op: mcms.builder.data.op.encode(this.testOps[i]),
-        proof: proofCell,
+        proof: this.opProofs[i],
       })
 
       const result = await this.bind.mcms.sendInternal(

--- a/contracts/tests/mcms/ManyChainMultiSigBaseTest.ts
+++ b/contracts/tests/mcms/ManyChainMultiSigBaseTest.ts
@@ -1,13 +1,11 @@
 import '@ton/test-utils'
 
 import { Blockchain, SandboxContract, TreasuryContract } from '@ton/sandbox'
-import { Address, Cell, Dictionary, toNano, beginCell, fromNano } from '@ton/core'
+import { Address, Cell, toNano, beginCell } from '@ton/core'
 import { compile } from '@ton/blueprint'
-import { randomBytes } from 'crypto'
 import { KeyPair, sign } from '@ton/crypto'
 
 import * as mcms from '../../wrappers/mcms/MCMS'
-import * as ownable2step from '../../wrappers/libraries/access/Ownable2Step'
 import { merkleProof } from '../../src/mcms'
 import * as counter from '../../wrappers/examples/Counter'
 
@@ -63,8 +61,8 @@ export class MCMSBaseTestSetup {
 
   // Test configuration
   testSigners: TestSigner[]
-  testGroupQuorums: Dictionary<number, number>
-  testGroupParents: Dictionary<number, number>
+  testGroupQuorums: Map<number, number>
+  testGroupParents: Map<number, number>
   signerGroups: number[]
   testConfig: mcms.Config
 
@@ -74,14 +72,8 @@ export class MCMSBaseTestSetup {
     this.acc = null as any
     this.bind = null as any
     this.testSigners = []
-    this.testGroupQuorums = Dictionary.empty<number, number>(
-      Dictionary.Keys.Uint(8),
-      Dictionary.Values.Uint(8),
-    )
-    this.testGroupParents = Dictionary.empty<number, number>(
-      Dictionary.Keys.Uint(8),
-      Dictionary.Values.Uint(8),
-    )
+    this.testGroupQuorums = new Map<number, number>()
+    this.testGroupParents = new Map<number, number>()
     this.signerGroups = []
     this.testConfig = null as any
   }
@@ -196,10 +188,7 @@ export class MCMSBaseTestSetup {
     }
 
     // Create the config
-    const signers = Dictionary.empty<number, Buffer>(
-      Dictionary.Keys.Uint(8),
-      Dictionary.Values.Buffer(mcms.LEN_SIGNER_BYTES),
-    )
+    const signers = new Map<number, Buffer>()
     for (let i = 0; i < this.testSigners.length; i++) {
       const signer = this.testSigners[i]
       const signerData = mcms.builder.data.signer.encode({
@@ -210,20 +199,10 @@ export class MCMSBaseTestSetup {
       signers.set(i, signerData.toBoc())
     }
 
-    const groupQuorums = Dictionary.empty<number, number>(
-      Dictionary.Keys.Uint(8),
-      Dictionary.Values.Uint(8),
-    )
-    const groupParents = Dictionary.empty<number, number>(
-      Dictionary.Keys.Uint(8),
-      Dictionary.Values.Uint(8),
-    )
+    const groupQuorums = new Map<number, number>()
+    const groupParents = new Map<number, number>()
 
-    for (
-      let i = 0;
-      i < MCMSBaseTestSetup.MAX_NUM_GROUPS && i < this.testGroupQuorums.keys().length;
-      i++
-    ) {
+    for (let i = 0; i < MCMSBaseTestSetup.MAX_NUM_GROUPS && i < this.testGroupQuorums.size; i++) {
       const currentGroupQuorum = this.testGroupQuorums.get(i)
       if (currentGroupQuorum && currentGroupQuorum > 0) {
         groupQuorums.set(i, currentGroupQuorum)
@@ -251,28 +230,13 @@ export class MCMSBaseTestSetup {
         owner: this.acc.multisigOwner.address,
         pendingOwner: null,
       },
-      signers: Dictionary.empty<bigint, Buffer>(
-        Dictionary.Keys.BigUint(256),
-        Dictionary.Values.Buffer(mcms.LEN_SIGNER_BYTES),
-      ),
+      signers: new Map<bigint, Buffer>(),
       config: {
-        signers: Dictionary.empty<number, Buffer>(
-          Dictionary.Keys.Uint(8),
-          Dictionary.Values.Buffer(mcms.LEN_SIGNER_BYTES),
-        ),
-        groupQuorums: Dictionary.empty<number, number>(
-          Dictionary.Keys.Uint(8),
-          Dictionary.Values.Uint(8),
-        ),
-        groupParents: Dictionary.empty<number, number>(
-          Dictionary.Keys.Uint(8),
-          Dictionary.Values.Uint(8),
-        ),
+        signers: new Map<number, Buffer>(),
+        groupQuorums: new Map<number, number>(),
+        groupParents: new Map<number, number>(),
       },
-      seenSignedHashes: Dictionary.empty<bigint, boolean>(
-        Dictionary.Keys.BigInt(256),
-        Dictionary.Values.Bool(),
-      ),
+      seenSignedHashes: new Map<bigint, boolean>(),
       expiringRootAndOpCount: {
         root: 0n,
         validUntil: 0n,
@@ -350,21 +314,13 @@ export class MCMSBaseTestSetup {
    */
   async setInitialConfiguration(): Promise<void> {
     // Build signer addresses cell
-    const signerKeys = asSnakeData<bigint>(
-      this.testSigners.map((s) => BigInt('0x' + s.keyPair.publicKey.toString('hex'))),
-      (a) => beginCell().storeUint(a, 256),
-    )
 
     // Build signer groups cell
-    const signerGroups = asSnakeData<number>(
-      this.testSigners.map((s) => s.group),
-      (g) => beginCell().storeUint(g, 8),
-    )
 
     const setConfigBody = mcms.builder.message.in.setConfig.encode({
       queryId: 1n,
-      signerKeys,
-      signerGroups,
+      signerKeys: this.testSigners.map((s) => BigInt('0x' + s.keyPair.publicKey.toString('hex'))),
+      signerGroups: this.testSigners.map((s) => s.group),
       groupQuorums: this.testConfig.groupQuorums,
       groupParents: this.testConfig.groupParents,
       clearRoot: false,

--- a/contracts/tests/mcms/ManyChainMultiSigBaseTest.ts
+++ b/contracts/tests/mcms/ManyChainMultiSigBaseTest.ts
@@ -319,7 +319,7 @@ export class MCMSBaseTestSetup {
 
     const setConfigBody = mcms.builder.message.in.setConfig.encode({
       queryId: 1n,
-      signerKeys: this.testSigners.map((s) => BigInt('0x' + s.keyPair.publicKey.toString('hex'))),
+      signerKeys: this.testSigners.map((s) => uint8ArrayToBigInt(s.keyPair.publicKey)),
       signerGroups: this.testSigners.map((s) => s.group),
       groupQuorums: this.testConfig.groupQuorums,
       groupParents: this.testConfig.groupParents,

--- a/contracts/tests/mcms/ManyChainMultiSigExecute.spec.ts
+++ b/contracts/tests/mcms/ManyChainMultiSigExecute.spec.ts
@@ -40,12 +40,11 @@ describe('MCMS - ManyChainMultiSigExecuteTest', () => {
     // Now try to execute one more operation - should fail with PostOpCountReached
     // Use any operation and proof - they won't even be checked
     const fakeOp = baseTest.testOps[0]
-    const fakeProof = asSnakeData<bigint>([], (v) => beginCell().storeUint(v, 256))
 
     const executeBody = mcms.builder.message.in.execute.encode({
       queryId: 999n,
       op: mcms.builder.data.op.encode(fakeOp),
-      proof: fakeProof,
+      proof: [], // fakeProof
     })
 
     const result = await baseTest.bind.mcms.sendInternal(
@@ -68,12 +67,10 @@ describe('MCMS - ManyChainMultiSigExecuteTest', () => {
     modifiedOp.value = modifiedOp.value + 1n
 
     // Try with empty proof first
-    const emptyProof = asSnakeData<bigint>([], (v) => beginCell().storeUint(v, 256))
-
     const executeBody1 = mcms.builder.message.in.execute.encode({
       queryId: 1n,
       op: mcms.builder.data.op.encode(modifiedOp),
-      proof: emptyProof,
+      proof: [], // emptyProof
     })
 
     const result1 = await baseTest.bind.mcms.sendInternal(
@@ -91,12 +88,11 @@ describe('MCMS - ManyChainMultiSigExecuteTest', () => {
 
     // Send a proof for the original op before the modification - should still fail
     const originalProof = baseTest.getProofForOp(0)
-    const proofCell = asSnakeData<bigint>(originalProof, (v) => beginCell().storeUint(v, 256))
 
     const executeBody2 = mcms.builder.message.in.execute.encode({
       queryId: 2n,
       op: mcms.builder.data.op.encode(modifiedOp),
-      proof: proofCell,
+      proof: originalProof,
     })
 
     const result2 = await baseTest.bind.mcms.sendInternal(
@@ -115,9 +111,7 @@ describe('MCMS - ManyChainMultiSigExecuteTest', () => {
 
   it('should revert on bad op data', async () => {
     // Create a dummy proof (5 elements as in original test)
-    const dummyProof = asSnakeData<bigint>([1n, 2n, 3n, 4n, 5n], (v) =>
-      beginCell().storeUint(v, 256),
-    )
+    const dummyProof = [1n, 2n, 3n, 4n, 5n]
 
     // Test 1: Wrong chain ID
     const wrongChainIdOp = { ...baseTest.testOps[0] }
@@ -214,12 +208,11 @@ describe('MCMS - ManyChainMultiSigExecuteTest', () => {
   it('should execute ops in order', async () => {
     // Execute first operation
     const proof1 = baseTest.getProofForOp(0)
-    const proofCell1 = asSnakeData<bigint>(proof1, (v) => beginCell().storeUint(v, 256))
 
     const executeBody1 = mcms.builder.message.in.execute.encode({
       queryId: 1n,
       op: mcms.builder.data.op.encode(baseTest.testOps[0]),
-      proof: proofCell1,
+      proof: proof1,
     })
 
     const result1 = await baseTest.bind.mcms.sendInternal(
@@ -254,12 +247,11 @@ describe('MCMS - ManyChainMultiSigExecuteTest', () => {
 
     // Try to execute the third op instead of the second - should fail with WrongNonce
     const proof3 = baseTest.getProofForOp(2)
-    const proofCell3 = asSnakeData<bigint>(proof3, (v) => beginCell().storeUint(v, 256))
 
     const executeBody3 = mcms.builder.message.in.execute.encode({
       queryId: 3n,
       op: mcms.builder.data.op.encode(baseTest.testOps[2]),
-      proof: proofCell3,
+      proof: proof3,
     })
 
     const result3Early = await baseTest.bind.mcms.sendInternal(
@@ -277,12 +269,11 @@ describe('MCMS - ManyChainMultiSigExecuteTest', () => {
 
     // Execute the second op correctly
     const proof2 = baseTest.getProofForOp(1)
-    const proofCell2 = asSnakeData<bigint>(proof2, (v) => beginCell().storeUint(v, 256))
 
     const executeBody2 = mcms.builder.message.in.execute.encode({
       queryId: 2n,
       op: mcms.builder.data.op.encode(baseTest.testOps[1]),
-      proof: proofCell2,
+      proof: proof2,
     })
 
     const result2 = await baseTest.bind.mcms.sendInternal(
@@ -313,14 +304,13 @@ describe('MCMS - ManyChainMultiSigExecuteTest', () => {
 
     // Now try to execute the reverting operation
     const proof = baseTest.getProofForOp(MCMSBaseSetRootAndExecuteTestSetup.REVERTING_OP_INDEX)
-    const proofCell = asSnakeData<bigint>(proof, (v) => beginCell().storeUint(v, 256))
 
     const executeBody = mcms.builder.message.in.execute.encode({
       queryId: BigInt(MCMSBaseSetRootAndExecuteTestSetup.REVERTING_OP_INDEX + 1),
       op: mcms.builder.data.op.encode(
         baseTest.testOps[MCMSBaseSetRootAndExecuteTestSetup.REVERTING_OP_INDEX],
       ),
-      proof: proofCell,
+      proof,
     })
 
     const result = await baseTest.bind.mcms.sendInternal(
@@ -355,14 +345,13 @@ describe('MCMS - ManyChainMultiSigExecuteTest', () => {
 
     // Try to execute value operation without sufficient balance
     const proof = baseTest.getProofForOp(MCMSBaseSetRootAndExecuteTestSetup.VALUE_OP_INDEX)
-    const proofCell = asSnakeData<bigint>(proof, (v) => beginCell().storeUint(v, 256))
 
     const executeBody = mcms.builder.message.in.execute.encode({
       queryId: BigInt(MCMSBaseSetRootAndExecuteTestSetup.VALUE_OP_INDEX + 1),
       op: mcms.builder.data.op.encode(
         baseTest.testOps[MCMSBaseSetRootAndExecuteTestSetup.VALUE_OP_INDEX],
       ),
-      proof: proofCell,
+      proof,
     })
 
     const result = await baseTest.bind.mcms.sendInternal(
@@ -391,14 +380,13 @@ describe('MCMS - ManyChainMultiSigExecuteTest', () => {
 
     // Execute the value operation
     const proof = baseTest.getProofForOp(MCMSBaseSetRootAndExecuteTestSetup.VALUE_OP_INDEX)
-    const proofCell = asSnakeData<bigint>(proof, (v) => beginCell().storeUint(v, 256))
 
     const executeBody = mcms.builder.message.in.execute.encode({
       queryId: BigInt(MCMSBaseSetRootAndExecuteTestSetup.VALUE_OP_INDEX + 1),
       op: mcms.builder.data.op.encode(
         baseTest.testOps[MCMSBaseSetRootAndExecuteTestSetup.VALUE_OP_INDEX],
       ),
-      proof: proofCell,
+      proof,
     })
 
     // TopUp contract before execution operation

--- a/contracts/tests/mcms/ManyChainMultiSigExecute.spec.ts
+++ b/contracts/tests/mcms/ManyChainMultiSigExecute.spec.ts
@@ -30,8 +30,7 @@ describe('MCMS - ManyChainMultiSigExecuteTest', () => {
       }),
     )
 
-    // Execute all operations up to the post-op count limit to simulate setOpCount // TODO this could be hidden behind some helper. It is not the focus of this test
-    await baseTest.advanceOpcodeTo(MCMSBaseSetRootAndExecuteTestSetup.OPS_NUM)
+    await baseTest.executeOperationsUpTo(MCMSBaseSetRootAndExecuteTestSetup.OPS_NUM)
 
     // Verify we've reached the post-op count
     const currentOpCount = await baseTest.bind.mcms.getOpCount()
@@ -296,7 +295,7 @@ describe('MCMS - ManyChainMultiSigExecuteTest', () => {
   // TODO mcms doesn't handle bounced messages yet
   it('should revert on failed op', async () => {
     // Execute operations up to the reverting op index
-    await baseTest.advanceOpcodeTo(MCMSBaseSetRootAndExecuteTestSetup.REVERTING_OP_INDEX)
+    await baseTest.executeOperationsUpTo(MCMSBaseSetRootAndExecuteTestSetup.REVERTING_OP_INDEX)
 
     // Verify we're at the correct op count
     const currentOpCount = await baseTest.bind.mcms.getOpCount()
@@ -332,7 +331,7 @@ describe('MCMS - ManyChainMultiSigExecuteTest', () => {
 
   it('should handle value operations correctly - insufficient balance', async () => {
     // Execute operations up to the value operation index
-    await baseTest.advanceOpcodeTo(MCMSBaseSetRootAndExecuteTestSetup.VALUE_OP_INDEX)
+    await baseTest.executeOperationsUpTo(MCMSBaseSetRootAndExecuteTestSetup.VALUE_OP_INDEX)
 
     // Verify we're at the correct op count
     const currentOpCount = await baseTest.bind.mcms.getOpCount()
@@ -371,7 +370,7 @@ describe('MCMS - ManyChainMultiSigExecuteTest', () => {
 
   it('should handle value operations correctly - with sufficient balance', async () => {
     // Execute operations up to the value operation index
-    await baseTest.advanceOpcodeTo(MCMSBaseSetRootAndExecuteTestSetup.VALUE_OP_INDEX)
+    await baseTest.executeOperationsUpTo(MCMSBaseSetRootAndExecuteTestSetup.VALUE_OP_INDEX)
 
     // Get the target address balance before executing the value operation
     const valueOp = baseTest.testOps[MCMSBaseSetRootAndExecuteTestSetup.VALUE_OP_INDEX]

--- a/contracts/tests/mcms/ManyChainMultiSigExecute.spec.ts
+++ b/contracts/tests/mcms/ManyChainMultiSigExecute.spec.ts
@@ -26,7 +26,7 @@ describe('MCMS - ManyChainMultiSigExecuteTest', () => {
       baseTest.acc.deployer.getSender(),
       toNano('10'),
       mcms.builder.message.in.topUp.encode({
-        queryId: BigInt(1),
+        queryId: 1n,
       }),
     )
 
@@ -406,7 +406,7 @@ describe('MCMS - ManyChainMultiSigExecuteTest', () => {
       baseTest.acc.deployer.getSender(),
       toNano('10'),
       mcms.builder.message.in.topUp.encode({
-        queryId: BigInt(1),
+        queryId: 1n,
       }),
     )
 

--- a/contracts/tests/mcms/ManyChainMultiSigSetConfig.spec.ts
+++ b/contracts/tests/mcms/ManyChainMultiSigSetConfig.spec.ts
@@ -5,6 +5,7 @@ import { toNano } from '@ton/core'
 import * as mcms from '../../wrappers/mcms/MCMS'
 
 import { MCMSBaseTestSetup, MCMSTestCode, TestSigner } from './ManyChainMultiSigBaseTest'
+import { uint8ArrayToBigInt } from '../../src/utils'
 
 describe('MCMS - ManyChainMultiSigSetConfigTest', () => {
   let baseTest: MCMSBaseTestSetup
@@ -24,9 +25,7 @@ describe('MCMS - ManyChainMultiSigSetConfigTest', () => {
     // Try to call setConfig from non-owner address (should fail)
     const setConfigBody = mcms.builder.message.in.setConfig.encode({
       queryId: 1n,
-      signerKeys: baseTest.testSigners.map((s) =>
-        BigInt('0x' + s.keyPair.publicKey.toString('hex')),
-      ),
+      signerKeys: baseTest.testSigners.map((s) => uint8ArrayToBigInt(s.keyPair.publicKey)),
       signerGroups: baseTest.testSigners.map((s) => s.group),
       groupQuorums: baseTest.testGroupQuorums,
       groupParents: baseTest.testGroupParents,
@@ -50,9 +49,7 @@ describe('MCMS - ManyChainMultiSigSetConfigTest', () => {
   it('should fail on invalid configuration - empty signers list', async () => {
     // Empty signers list should fail
     const emptySignerList: TestSigner[] = []
-    const emptySignerKeys = emptySignerList.map((s) =>
-      BigInt('0x' + s.keyPair.publicKey.toString('hex')),
-    )
+    const emptySignerKeys = emptySignerList.map((s) => uint8ArrayToBigInt(s.keyPair.publicKey))
     const emptySignerGroups = emptySignerList.map((s) => s.group)
 
     const setConfigBody = mcms.builder.message.in.setConfig.encode({
@@ -83,9 +80,7 @@ describe('MCMS - ManyChainMultiSigSetConfigTest', () => {
 
     const duplicateSigners = [...baseTest.testSigners]
     duplicateSigners[1] = duplicateSigners[0] // Make addresses duplicate
-    const signerKeys = duplicateSigners.map((s) =>
-      BigInt('0x' + s.keyPair.publicKey.toString('hex')),
-    )
+    const signerKeys = duplicateSigners.map((s) => uint8ArrayToBigInt(s.keyPair.publicKey))
     const signerGroups = duplicateSigners.map((s) => s.group)
 
     const setConfigBody = mcms.builder.message.in.setConfig.encode({
@@ -116,9 +111,7 @@ describe('MCMS - ManyChainMultiSigSetConfigTest', () => {
     const invalidGroupSigners = [...baseTest.testSigners]
     invalidGroupSigners[0].group = mcms.NUM_GROUPS + 1
 
-    const signerKeys = invalidGroupSigners.map((s) =>
-      BigInt('0x' + s.keyPair.publicKey.toString('hex')),
-    )
+    const signerKeys = invalidGroupSigners.map((s) => uint8ArrayToBigInt(s.keyPair.publicKey))
     const signerGroups = invalidGroupSigners.map((s) => s.group)
 
     const setConfigBody = mcms.builder.message.in.setConfig.encode({
@@ -157,9 +150,7 @@ describe('MCMS - ManyChainMultiSigSetConfigTest', () => {
 
     const setConfigBody = mcms.builder.message.in.setConfig.encode({
       queryId: 1n,
-      signerKeys: baseTest.testSigners.map((s) =>
-        BigInt('0x' + s.keyPair.publicKey.toString('hex')),
-      ),
+      signerKeys: baseTest.testSigners.map((s) => uint8ArrayToBigInt(s.keyPair.publicKey)),
       signerGroups: baseTest.testSigners.map((s) => s.group),
       groupQuorums: invalidGroupQuorums,
       groupParents: baseTest.testGroupParents,
@@ -193,9 +184,7 @@ describe('MCMS - ManyChainMultiSigSetConfigTest', () => {
 
     const setConfigBody = mcms.builder.message.in.setConfig.encode({
       queryId: 1n,
-      signerKeys: baseTest.testSigners.map((s) =>
-        BigInt('0x' + s.keyPair.publicKey.toString('hex')),
-      ),
+      signerKeys: baseTest.testSigners.map((s) => uint8ArrayToBigInt(s.keyPair.publicKey)),
       signerGroups: baseTest.testSigners.map((s) => s.group),
       groupQuorums: baseTest.testGroupQuorums,
       groupParents: invalidGroupParents,
@@ -229,9 +218,7 @@ describe('MCMS - ManyChainMultiSigSetConfigTest', () => {
 
     const setConfigBody = mcms.builder.message.in.setConfig.encode({
       queryId: 1n,
-      signerKeys: baseTest.testSigners.map((s) =>
-        BigInt('0x' + s.keyPair.publicKey.toString('hex')),
-      ),
+      signerKeys: baseTest.testSigners.map((s) => uint8ArrayToBigInt(s.keyPair.publicKey)),
       signerGroups: baseTest.testSigners.map((s) => s.group),
       groupQuorums: baseTest.testGroupQuorums,
       groupParents: invalidGroupParents,
@@ -259,9 +246,7 @@ describe('MCMS - ManyChainMultiSigSetConfigTest', () => {
 
     const setConfigBody = mcms.builder.message.in.setConfig.encode({
       queryId: 1n,
-      signerKeys: baseTest.testSigners.map((s) =>
-        BigInt('0x' + s.keyPair.publicKey.toString('hex')),
-      ),
+      signerKeys: baseTest.testSigners.map((s) => uint8ArrayToBigInt(s.keyPair.publicKey)),
       signerGroups: disabledGroupSigners.map((s) => s.group),
       groupQuorums: baseTest.testGroupQuorums,
       groupParents: baseTest.testGroupParents,
@@ -289,7 +274,7 @@ describe('MCMS - ManyChainMultiSigSetConfigTest', () => {
 
     const setConfigBody = mcms.builder.message.in.setConfig.encode({
       queryId: 1n,
-      signerKeys: signer.map((s) => BigInt('0x' + s.keyPair.publicKey.toString('hex'))),
+      signerKeys: signer.map((s) => uint8ArrayToBigInt(s.keyPair.publicKey)),
       signerGroups: shorterSignerGroup.map((s) => s.group),
       groupQuorums: baseTest.testGroupQuorums,
       groupParents: baseTest.testGroupParents,
@@ -313,9 +298,7 @@ describe('MCMS - ManyChainMultiSigSetConfigTest', () => {
   it('should successfully set config without clearing root', async () => {
     const setConfigBody = mcms.builder.message.in.setConfig.encode({
       queryId: 1n,
-      signerKeys: baseTest.testSigners.map((s) =>
-        BigInt('0x' + s.keyPair.publicKey.toString('hex')),
-      ),
+      signerKeys: baseTest.testSigners.map((s) => uint8ArrayToBigInt(s.keyPair.publicKey)),
       signerGroups: baseTest.testSigners.map((s) => s.group),
       groupQuorums: baseTest.testGroupQuorums,
       groupParents: baseTest.testGroupParents,
@@ -358,9 +341,7 @@ describe('MCMS - ManyChainMultiSigSetConfigTest', () => {
   it('should successfully set config and clear root', async () => {
     const setConfigBody = mcms.builder.message.in.setConfig.encode({
       queryId: 1n,
-      signerKeys: baseTest.testSigners.map((s) =>
-        BigInt('0x' + s.keyPair.publicKey.toString('hex')),
-      ),
+      signerKeys: baseTest.testSigners.map((s) => uint8ArrayToBigInt(s.keyPair.publicKey)),
       signerGroups: baseTest.testSigners.map((s) => s.group),
       groupQuorums: baseTest.testGroupQuorums,
       groupParents: baseTest.testGroupParents,

--- a/contracts/tests/mcms/ManyChainMultiSigSetConfig.spec.ts
+++ b/contracts/tests/mcms/ManyChainMultiSigSetConfig.spec.ts
@@ -1,13 +1,10 @@
 import '@ton/test-utils'
 
-import { Address, toNano, Dictionary, beginCell } from '@ton/core'
-import * as ac from '../../wrappers/lib/access/AccessControl'
+import { toNano } from '@ton/core'
 
 import * as mcms from '../../wrappers/mcms/MCMS'
 
 import { MCMSBaseTestSetup, MCMSTestCode, TestSigner } from './ManyChainMultiSigBaseTest'
-import { asSnakeData } from '../../src/utils'
-import { KeyPair } from '@ton/crypto'
 
 describe('MCMS - ManyChainMultiSigSetConfigTest', () => {
   let baseTest: MCMSBaseTestSetup
@@ -27,14 +24,10 @@ describe('MCMS - ManyChainMultiSigSetConfigTest', () => {
     // Try to call setConfig from non-owner address (should fail)
     const setConfigBody = mcms.builder.message.in.setConfig.encode({
       queryId: 1n,
-      signerKeys: asSnakeData<bigint>(
-        baseTest.testSigners.map((s) => BigInt('0x' + s.keyPair.publicKey.toString('hex'))),
-        (a) => beginCell().storeUint(a, 256),
+      signerKeys: baseTest.testSigners.map((s) =>
+        BigInt('0x' + s.keyPair.publicKey.toString('hex')),
       ),
-      signerGroups: asSnakeData<number>(
-        baseTest.testSigners.map((s) => s.group),
-        (g) => beginCell().storeUint(g, 8),
-      ),
+      signerGroups: baseTest.testSigners.map((s) => s.group),
       groupQuorums: baseTest.testGroupQuorums,
       groupParents: baseTest.testGroupParents,
       clearRoot: false,
@@ -57,14 +50,10 @@ describe('MCMS - ManyChainMultiSigSetConfigTest', () => {
   it('should fail on invalid configuration - empty signers list', async () => {
     // Empty signers list should fail
     const emptySignerList: TestSigner[] = []
-    const emptySignerKeys = asSnakeData<bigint>(
-      emptySignerList.map((s) => BigInt('0x' + s.keyPair.publicKey.toString('hex'))),
-      (a) => beginCell().storeUint(a, 256),
+    const emptySignerKeys = emptySignerList.map((s) =>
+      BigInt('0x' + s.keyPair.publicKey.toString('hex')),
     )
-    const emptySignerGroups = asSnakeData<number>(
-      emptySignerList.map((s) => s.group),
-      (g) => beginCell().storeUint(g, 8),
-    )
+    const emptySignerGroups = emptySignerList.map((s) => s.group)
 
     const setConfigBody = mcms.builder.message.in.setConfig.encode({
       queryId: 1n,
@@ -94,14 +83,10 @@ describe('MCMS - ManyChainMultiSigSetConfigTest', () => {
 
     const duplicateSigners = [...baseTest.testSigners]
     duplicateSigners[1] = duplicateSigners[0] // Make addresses duplicate
-    const signerKeys = asSnakeData<bigint>(
-      duplicateSigners.map((s) => BigInt('0x' + s.keyPair.publicKey.toString('hex'))),
-      (a) => beginCell().storeUint(a, 256),
+    const signerKeys = duplicateSigners.map((s) =>
+      BigInt('0x' + s.keyPair.publicKey.toString('hex')),
     )
-    const signerGroups = asSnakeData<number>(
-      duplicateSigners.map((s) => s.group),
-      (g) => beginCell().storeUint(g, 8),
-    )
+    const signerGroups = duplicateSigners.map((s) => s.group)
 
     const setConfigBody = mcms.builder.message.in.setConfig.encode({
       queryId: 1n,
@@ -131,14 +116,10 @@ describe('MCMS - ManyChainMultiSigSetConfigTest', () => {
     const invalidGroupSigners = [...baseTest.testSigners]
     invalidGroupSigners[0].group = mcms.NUM_GROUPS + 1
 
-    const signerKeys = asSnakeData<bigint>(
-      invalidGroupSigners.map((s) => BigInt('0x' + s.keyPair.publicKey.toString('hex'))),
-      (a) => beginCell().storeUint(a, 256),
+    const signerKeys = invalidGroupSigners.map((s) =>
+      BigInt('0x' + s.keyPair.publicKey.toString('hex')),
     )
-    const signerGroups = asSnakeData<number>(
-      invalidGroupSigners.map((s) => s.group),
-      (g) => beginCell().storeUint(g, 8),
-    )
+    const signerGroups = invalidGroupSigners.map((s) => s.group)
 
     const setConfigBody = mcms.builder.message.in.setConfig.encode({
       queryId: 1n,
@@ -165,10 +146,7 @@ describe('MCMS - ManyChainMultiSigSetConfigTest', () => {
 
   it('should fail on invalid configuration - too large group quorum', async () => {
     // Set quorum larger than number of signers
-    const invalidGroupQuorums = Dictionary.empty<number, number>(
-      Dictionary.Keys.Uint(8),
-      Dictionary.Values.Uint(8),
-    )
+    const invalidGroupQuorums = new Map<number, number>()
     for (let i = 0; i < mcms.NUM_GROUPS; i++) {
       if (i === 0) {
         invalidGroupQuorums.set(i, MCMSBaseTestSetup.SIGNERS_NUM + 1) // Too large
@@ -179,14 +157,10 @@ describe('MCMS - ManyChainMultiSigSetConfigTest', () => {
 
     const setConfigBody = mcms.builder.message.in.setConfig.encode({
       queryId: 1n,
-      signerKeys: asSnakeData<bigint>(
-        baseTest.testSigners.map((s) => BigInt('0x' + s.keyPair.publicKey.toString('hex'))),
-        (a) => beginCell().storeUint(a, 256),
+      signerKeys: baseTest.testSigners.map((s) =>
+        BigInt('0x' + s.keyPair.publicKey.toString('hex')),
       ),
-      signerGroups: asSnakeData<number>(
-        baseTest.testSigners.map((s) => s.group),
-        (g) => beginCell().storeUint(g, 8),
-      ),
+      signerGroups: baseTest.testSigners.map((s) => s.group),
       groupQuorums: invalidGroupQuorums,
       groupParents: baseTest.testGroupParents,
       clearRoot: false,
@@ -208,10 +182,7 @@ describe('MCMS - ManyChainMultiSigSetConfigTest', () => {
 
   it('should fail on invalid configuration - malformed group tree (root not self-parent)', async () => {
     // Root group (0) should have itself as parent, not another group
-    const invalidGroupParents = Dictionary.empty<number, number>(
-      Dictionary.Keys.Uint(8),
-      Dictionary.Values.Uint(8),
-    )
+    const invalidGroupParents = new Map<number, number>()
     for (let i = 0; i < mcms.NUM_GROUPS; i++) {
       if (i === 0) {
         invalidGroupParents.set(i, 1) // Invalid: root should be self-parent (0)
@@ -222,14 +193,10 @@ describe('MCMS - ManyChainMultiSigSetConfigTest', () => {
 
     const setConfigBody = mcms.builder.message.in.setConfig.encode({
       queryId: 1n,
-      signerKeys: asSnakeData<bigint>(
-        baseTest.testSigners.map((s) => BigInt('0x' + s.keyPair.publicKey.toString('hex'))),
-        (a) => beginCell().storeUint(a, 256),
+      signerKeys: baseTest.testSigners.map((s) =>
+        BigInt('0x' + s.keyPair.publicKey.toString('hex')),
       ),
-      signerGroups: asSnakeData<number>(
-        baseTest.testSigners.map((s) => s.group),
-        (g) => beginCell().storeUint(g, 8),
-      ),
+      signerGroups: baseTest.testSigners.map((s) => s.group),
       groupQuorums: baseTest.testGroupQuorums,
       groupParents: invalidGroupParents,
       clearRoot: false,
@@ -251,10 +218,7 @@ describe('MCMS - ManyChainMultiSigSetConfigTest', () => {
 
   it('should fail on invalid configuration - malformed group tree (group self-parent)', async () => {
     // Non-root group should not have itself as parent
-    const invalidGroupParents = Dictionary.empty<number, number>(
-      Dictionary.Keys.Uint(8),
-      Dictionary.Values.Uint(8),
-    )
+    const invalidGroupParents = new Map<number, number>()
     for (let i = 0; i < mcms.NUM_GROUPS; i++) {
       if (i === 1) {
         invalidGroupParents.set(i, 1) // Invalid: group 1 has itself as parent
@@ -265,14 +229,10 @@ describe('MCMS - ManyChainMultiSigSetConfigTest', () => {
 
     const setConfigBody = mcms.builder.message.in.setConfig.encode({
       queryId: 1n,
-      signerKeys: asSnakeData<bigint>(
-        baseTest.testSigners.map((s) => BigInt('0x' + s.keyPair.publicKey.toString('hex'))),
-        (a) => beginCell().storeUint(a, 256),
+      signerKeys: baseTest.testSigners.map((s) =>
+        BigInt('0x' + s.keyPair.publicKey.toString('hex')),
       ),
-      signerGroups: asSnakeData<number>(
-        baseTest.testSigners.map((s) => s.group),
-        (g) => beginCell().storeUint(g, 8),
-      ),
+      signerGroups: baseTest.testSigners.map((s) => s.group),
       groupQuorums: baseTest.testGroupQuorums,
       groupParents: invalidGroupParents,
       clearRoot: false,
@@ -299,14 +259,10 @@ describe('MCMS - ManyChainMultiSigSetConfigTest', () => {
 
     const setConfigBody = mcms.builder.message.in.setConfig.encode({
       queryId: 1n,
-      signerKeys: asSnakeData<bigint>(
-        baseTest.testSigners.map((s) => BigInt('0x' + s.keyPair.publicKey.toString('hex'))),
-        (a) => beginCell().storeUint(a, 256),
+      signerKeys: baseTest.testSigners.map((s) =>
+        BigInt('0x' + s.keyPair.publicKey.toString('hex')),
       ),
-      signerGroups: asSnakeData<number>(
-        disabledGroupSigners.map((s) => s.group),
-        (g) => beginCell().storeUint(g, 8),
-      ),
+      signerGroups: disabledGroupSigners.map((s) => s.group),
       groupQuorums: baseTest.testGroupQuorums,
       groupParents: baseTest.testGroupParents,
       clearRoot: false,
@@ -333,14 +289,8 @@ describe('MCMS - ManyChainMultiSigSetConfigTest', () => {
 
     const setConfigBody = mcms.builder.message.in.setConfig.encode({
       queryId: 1n,
-      signerKeys: asSnakeData<bigint>(
-        signer.map((s) => BigInt('0x' + s.keyPair.publicKey.toString('hex'))),
-        (a) => beginCell().storeUint(a, 256),
-      ),
-      signerGroups: asSnakeData<number>(
-        shorterSignerGroup.map((s) => s.group),
-        (g) => beginCell().storeUint(g, 8),
-      ),
+      signerKeys: signer.map((s) => BigInt('0x' + s.keyPair.publicKey.toString('hex'))),
+      signerGroups: shorterSignerGroup.map((s) => s.group),
       groupQuorums: baseTest.testGroupQuorums,
       groupParents: baseTest.testGroupParents,
       clearRoot: false,
@@ -363,14 +313,10 @@ describe('MCMS - ManyChainMultiSigSetConfigTest', () => {
   it('should successfully set config without clearing root', async () => {
     const setConfigBody = mcms.builder.message.in.setConfig.encode({
       queryId: 1n,
-      signerKeys: asSnakeData<bigint>(
-        baseTest.testSigners.map((s) => BigInt('0x' + s.keyPair.publicKey.toString('hex'))),
-        (a) => beginCell().storeUint(a, 256),
+      signerKeys: baseTest.testSigners.map((s) =>
+        BigInt('0x' + s.keyPair.publicKey.toString('hex')),
       ),
-      signerGroups: asSnakeData<number>(
-        baseTest.testSigners.map((s) => s.group),
-        (g) => beginCell().storeUint(g, 8),
-      ),
+      signerGroups: baseTest.testSigners.map((s) => s.group),
       groupQuorums: baseTest.testGroupQuorums,
       groupParents: baseTest.testGroupParents,
       clearRoot: false,
@@ -412,14 +358,10 @@ describe('MCMS - ManyChainMultiSigSetConfigTest', () => {
   it('should successfully set config and clear root', async () => {
     const setConfigBody = mcms.builder.message.in.setConfig.encode({
       queryId: 1n,
-      signerKeys: asSnakeData<bigint>(
-        baseTest.testSigners.map((s) => BigInt('0x' + s.keyPair.publicKey.toString('hex'))),
-        (a) => beginCell().storeUint(a, 256),
+      signerKeys: baseTest.testSigners.map((s) =>
+        BigInt('0x' + s.keyPair.publicKey.toString('hex')),
       ),
-      signerGroups: asSnakeData<number>(
-        baseTest.testSigners.map((s) => s.group),
-        (g) => beginCell().storeUint(g, 8),
-      ),
+      signerGroups: baseTest.testSigners.map((s) => s.group),
       groupQuorums: baseTest.testGroupQuorums,
       groupParents: baseTest.testGroupParents,
       clearRoot: true, // Clear the root

--- a/contracts/tests/mcms/ManyChainMultiSigSetConfig.spec.ts
+++ b/contracts/tests/mcms/ManyChainMultiSigSetConfig.spec.ts
@@ -3,6 +3,7 @@ import '@ton/test-utils'
 import { toNano } from '@ton/core'
 
 import * as mcms from '../../wrappers/mcms/MCMS'
+import * as ownable2Step from '../../wrappers/libraries/access/Ownable2Step'
 
 import { MCMSBaseTestSetup, MCMSTestCode, TestSigner } from './ManyChainMultiSigBaseTest'
 import { uint8ArrayToBigInt } from '../../src/utils'
@@ -42,7 +43,7 @@ describe('MCMS - ManyChainMultiSigSetConfigTest', () => {
       from: baseTest.acc.deployer.address,
       to: baseTest.bind.mcms.address,
       success: false,
-      exitCode: 132, // ERROR_ONLY_CALLABLE_BY_OWNER(ownable_2step) // TODO: This should be exposed by some binding.
+      exitCode: ownable2Step.Errors.OnlyCallableByOwner,
     })
   })
 

--- a/contracts/tests/mcms/ManyChainMultiSigSetRoot.spec.ts
+++ b/contracts/tests/mcms/ManyChainMultiSigSetRoot.spec.ts
@@ -728,7 +728,6 @@ describe('MCMS - ManyChainMultiSigSetRootTest', () => {
       const corruptedMetadata = { ...baseTest.initialTestRootMetadata }
       corruptedMetadata.chainId = corruptedMetadata.chainId + 1n
       // Note: We also need to set the blockchain chainId to match for the chainId validation
-      baseTest.blockchain.now = 1 // Reset time if needed // TODO do we need this?
 
       const signers = baseTest.testSigners.map((s) => ({
         publicKey: s.keyPair.publicKey,

--- a/contracts/tests/mcms/ManyChainMultiSigSetRoot.spec.ts
+++ b/contracts/tests/mcms/ManyChainMultiSigSetRoot.spec.ts
@@ -121,7 +121,7 @@ describe('MCMS - ManyChainMultiSigSetRootTest', () => {
 
     it('should revert on incorrect preOpCount - opCount > preOpCount', async () => {
       await baseTest.setInitialRoot()
-      await baseTest.advanceOpcodeTo(1)
+      await baseTest.executeOperationsUpTo(1)
       const corruptedRootMetadata = { ...baseTest.initialTestRootMetadata }
       corruptedRootMetadata.overridePreviousRoot = true
       corruptedRootMetadata.preOpCount = (await baseTest.bind.mcms.getOpCount()) - 1n
@@ -160,7 +160,7 @@ describe('MCMS - ManyChainMultiSigSetRootTest', () => {
         toNano('10'),
         mcms.builder.message.in.topUp.encode({ queryId: 1n }),
       )
-      await baseTest.advanceOpcodeTo(MCMSBaseSetRootAndExecuteTestSetup.OPS_NUM)
+      await baseTest.executeOperationsUpTo(MCMSBaseSetRootAndExecuteTestSetup.OPS_NUM)
 
       // Now try to set another root with incorrect postOpCount
       const corruptedRootMetadata = { ...baseTest.initialTestRootMetadata }
@@ -417,7 +417,7 @@ describe('MCMS - ManyChainMultiSigSetRootTest', () => {
     it('should successfully set root after clearing', async () => {
       // Execute all ops except one
       const targetOpCount = baseTest.initialTestRootMetadata.postOpCount - 1n
-      await baseTest.advanceOpcodeTo(Number(targetOpCount))
+      await baseTest.executeOperationsUpTo(Number(targetOpCount))
 
       // Set config with clearRoot = true
       const setConfigBody = mcms.builder.message.in.setConfig.encode({
@@ -572,7 +572,7 @@ describe('MCMS - ManyChainMultiSigSetRootTest', () => {
       newRootMetadata.postOpCount =
         newRootMetadata.preOpCount + BigInt(MCMSBaseSetRootAndExecuteTestSetup.OPS_NUM)
 
-      await baseTest.advanceOpcodeTo(MCMSBaseSetRootAndExecuteTestSetup.OPS_NUM)
+      await baseTest.executeOperationsUpTo(MCMSBaseSetRootAndExecuteTestSetup.OPS_NUM)
 
       const signers = baseTest.testSigners.map((s) => ({
         publicKey: s.keyPair.publicKey,

--- a/contracts/tests/mcms/ManyChainMultiSigSetRoot.spec.ts
+++ b/contracts/tests/mcms/ManyChainMultiSigSetRoot.spec.ts
@@ -8,6 +8,7 @@ import {
 import { merkleProof } from '../../src/mcms'
 import * as mcms from '../../wrappers/mcms/MCMS'
 import { sign } from '@ton/crypto/dist/primitives/nacl'
+import { uint8ArrayToBigInt } from '../../src/utils'
 
 describe('MCMS - ManyChainMultiSigSetRootTest', () => {
   let baseTest: MCMSBaseSetRootAndExecuteTestSetup
@@ -421,9 +422,7 @@ describe('MCMS - ManyChainMultiSigSetRootTest', () => {
       // Set config with clearRoot = true
       const setConfigBody = mcms.builder.message.in.setConfig.encode({
         queryId: 1n,
-        signerKeys: baseTest.testSigners.map((s) =>
-          BigInt('0x' + s.keyPair.publicKey.toString('hex')),
-        ),
+        signerKeys: baseTest.testSigners.map((s) => uint8ArrayToBigInt(s.keyPair.publicKey)),
         signerGroups: baseTest.testSigners.map((s) => s.group),
         groupQuorums: baseTest.testGroupQuorums,
         groupParents: baseTest.testGroupParents,
@@ -784,7 +783,7 @@ describe('MCMS - ManyChainMultiSigSetRootTest', () => {
       {
         const setConfigBody = mcms.builder.message.in.setConfig.encode({
           queryId: 1n,
-          signerKeys: signers.map((s) => BigInt('0x' + s.keyPair.publicKey.toString('hex'))),
+          signerKeys: signers.map((s) => uint8ArrayToBigInt(s.keyPair.publicKey)),
           signerGroups,
           groupQuorums: stricterGroupQuorums,
           groupParents: baseTest.testGroupParents,

--- a/contracts/tests/mcms/ManyChainMultiSigSetRoot.spec.ts
+++ b/contracts/tests/mcms/ManyChainMultiSigSetRoot.spec.ts
@@ -1,7 +1,5 @@
-import { toNano, beginCell, Cell, Address, Dictionary } from '@ton/core'
-import { Blockchain, SandboxContract, TreasuryContract } from '@ton/sandbox'
+import { toNano, beginCell } from '@ton/core'
 import '@ton/test-utils'
-import { compile } from '@ton/blueprint'
 import {
   MCMSBaseSetRootAndExecuteTestSetup,
   MCMSTestCode,
@@ -10,7 +8,6 @@ import {
 import { merkleProof } from '../../src/mcms'
 import * as mcms from '../../wrappers/mcms/MCMS'
 import { sign } from '@ton/crypto/dist/primitives/nacl'
-import { asSnakeData } from '../../src/utils'
 
 describe('MCMS - ManyChainMultiSigSetRootTest', () => {
   let baseTest: MCMSBaseSetRootAndExecuteTestSetup
@@ -424,14 +421,10 @@ describe('MCMS - ManyChainMultiSigSetRootTest', () => {
       // Set config with clearRoot = true
       const setConfigBody = mcms.builder.message.in.setConfig.encode({
         queryId: 1n,
-        signerKeys: asSnakeData<bigint>(
-          baseTest.testSigners.map((s) => BigInt('0x' + s.keyPair.publicKey.toString('hex'))),
-          (a) => beginCell().storeUint(a, 256),
+        signerKeys: baseTest.testSigners.map((s) =>
+          BigInt('0x' + s.keyPair.publicKey.toString('hex')),
         ),
-        signerGroups: asSnakeData<number>(
-          baseTest.testSigners.map((s) => s.group),
-          (g) => beginCell().storeUint(g, 8),
-        ),
+        signerGroups: baseTest.testSigners.map((s) => s.group),
         groupQuorums: baseTest.testGroupQuorums,
         groupParents: baseTest.testGroupParents,
         clearRoot: true,
@@ -770,10 +763,7 @@ describe('MCMS - ManyChainMultiSigSetRootTest', () => {
       const signersNum = 9
       // expect(signersNum).toBeGreaterThanOrEqual(baseTest.SIGNERS_NUM) // TODO why can't I access it?
       // Create a configuration with stricter quorum requirements
-      const stricterGroupQuorums = Dictionary.empty<number, number>(
-        Dictionary.Keys.Uint(8),
-        Dictionary.Values.Uint(8),
-      )
+      const stricterGroupQuorums = new Map<number, number>()
       stricterGroupQuorums.set(0, 3) // Increase root group quorum to 3
       stricterGroupQuorums.set(1, 3) // Group 1 needs 3 signatures
       stricterGroupQuorums.set(2, 2) // Group 2 needs 2 signatures
@@ -794,11 +784,8 @@ describe('MCMS - ManyChainMultiSigSetRootTest', () => {
       {
         const setConfigBody = mcms.builder.message.in.setConfig.encode({
           queryId: 1n,
-          signerKeys: asSnakeData<bigint>(
-            signers.map((s) => BigInt('0x' + s.keyPair.publicKey.toString('hex'))),
-            (a) => beginCell().storeUint(a, 256),
-          ),
-          signerGroups: asSnakeData<number>(signerGroups, (g) => beginCell().storeUint(g, 8)),
+          signerKeys: signers.map((s) => BigInt('0x' + s.keyPair.publicKey.toString('hex'))),
+          signerGroups,
           groupQuorums: stricterGroupQuorums,
           groupParents: baseTest.testGroupParents,
           clearRoot: false,

--- a/contracts/tests/mcms/ManyChainMultiSigSetRoot.spec.ts
+++ b/contracts/tests/mcms/ManyChainMultiSigSetRoot.spec.ts
@@ -760,7 +760,7 @@ describe('MCMS - ManyChainMultiSigSetRootTest', () => {
   describe('SetRootVerifySignaturesTest', () => {
     it('should revert on insufficient signatures for group quorum', async () => {
       const signersNum = 9
-      // expect(signersNum).toBeGreaterThanOrEqual(baseTest.SIGNERS_NUM) // TODO why can't I access it?
+      expect(signersNum).toBeGreaterThanOrEqual(MCMSBaseSetRootAndExecuteTestSetup.SIGNERS_NUM)
       // Create a configuration with stricter quorum requirements
       const stricterGroupQuorums = new Map<number, number>()
       stricterGroupQuorums.set(0, 3) // Increase root group quorum to 3

--- a/contracts/tests/mcms/ManyChainMultiSigSubgroups.spec.ts
+++ b/contracts/tests/mcms/ManyChainMultiSigSubgroups.spec.ts
@@ -143,7 +143,7 @@ describe('MCMS - ManyChainMultiSigSubgroupsTest', () => {
     {
       const setConfigBody = mcms.builder.message.in.setConfig.encode({
         queryId: 1n,
-        signerKeys: testSigners.map((s) => BigInt('0x' + s.keyPair.publicKey.toString('hex'))),
+        signerKeys: testSigners.map((s) => uint8ArrayToBigInt(s.keyPair.publicKey)),
         signerGroups: testSigners.map((s) => s.group),
         groupQuorums,
         groupParents,
@@ -272,7 +272,7 @@ describe('MCMS - ManyChainMultiSigSubgroupsTest', () => {
 
     // Set configuration
     {
-      const signers = testSigners.map((s) => BigInt('0x' + s.keyPair.publicKey.toString('hex')))
+      const signers = testSigners.map((s) => uint8ArrayToBigInt(s.keyPair.publicKey))
 
       const setConfigBody = mcms.builder.message.in.setConfig.encode({
         queryId: 1n,
@@ -419,7 +419,7 @@ describe('MCMS - ManyChainMultiSigSubgroupsTest', () => {
     // Test malformed configuration should fail
     const malformedSetConfigBody = mcms.builder.message.in.setConfig.encode({
       queryId: 1n,
-      signerKeys: testSigners.map((s) => BigInt('0x' + s.keyPair.publicKey.toString('hex'))),
+      signerKeys: testSigners.map((s) => uint8ArrayToBigInt(s.keyPair.publicKey)),
       signerGroups: signerGroupsData,
       groupQuorums,
       groupParents: malformedGroupParents,
@@ -448,7 +448,7 @@ describe('MCMS - ManyChainMultiSigSubgroupsTest', () => {
 
     const correctSetConfigBody = mcms.builder.message.in.setConfig.encode({
       queryId: 2n,
-      signerKeys: testSigners.map((s) => BigInt('0x' + s.keyPair.publicKey.toString('hex'))),
+      signerKeys: testSigners.map((s) => uint8ArrayToBigInt(s.keyPair.publicKey)),
       signerGroups: signerGroupsData,
       groupQuorums,
       groupParents: correctGroupParents,

--- a/contracts/tests/mcms/ManyChainMultiSigSubgroups.spec.ts
+++ b/contracts/tests/mcms/ManyChainMultiSigSubgroups.spec.ts
@@ -72,7 +72,7 @@ describe('MCMS - ManyChainMultiSigSubgroupsTest', () => {
         testSigners.push({
           address,
           keyPair: keyPairs[i],
-          treasury: treasury,
+          wallet: treasury,
           index: i,
           group: 0, // Will be set per test
         })

--- a/contracts/tests/mcms/ManyChainMultiSigSubgroups.spec.ts
+++ b/contracts/tests/mcms/ManyChainMultiSigSubgroups.spec.ts
@@ -4,10 +4,12 @@ import '@ton/test-utils'
 import { MCMSBaseTestSetup, MCMSTestCode, TestSigner } from './ManyChainMultiSigBaseTest'
 import { merkleProof } from '../../src/mcms'
 import * as mcms from '../../wrappers/mcms/MCMS'
+import * as counter from '../../wrappers/examples/Counter'
 import { uint8ArrayToBigInt } from '../../src/utils'
 import { sha256, sign } from '@ton/crypto'
 import { ocr } from '../../wrappers/libraries/ocr'
 import { generateEd25519KeyPair } from '../libraries/ocr/Helpers'
+import { crc32 } from 'zlib'
 
 describe('MCMS - ManyChainMultiSigSubgroupsTest', () => {
   let blockchain: Blockchain
@@ -19,6 +21,7 @@ describe('MCMS - ManyChainMultiSigSubgroupsTest', () => {
   }
   let bind: {
     mcms: SandboxContract<mcms.ContractClient>
+    counter: SandboxContract<counter.ContractClient>
   }
 
   const MCMS_NUM_GROUPS = 32
@@ -70,15 +73,27 @@ describe('MCMS - ManyChainMultiSigSubgroupsTest', () => {
       }
     }
 
+    const testId = crc32('mcms.manyChainMultiSigSubgroupTest')
+    const mcmsBind = blockchain.openContract(
+      mcms.ContractClient.newFrom(
+        mcms.builder.data.contractDataEmpty(testId, acc.multisigOwner.address),
+        code.mcms,
+      ),
+    )
     // Set up MCMS contract
     bind = {
-      mcms: blockchain.openContract(
-        mcms.ContractClient.newFrom(
-          mcms.builder.data.contractDataEmpty(
-            123456, // test ID
-            acc.multisigOwner.address,
-          ),
-          code.mcms,
+      mcms: mcmsBind,
+      counter: blockchain.openContract(
+        counter.ContractClient.newFrom(
+          {
+            id: testId,
+            value: 0,
+            ownable: {
+              owner: mcmsBind.address,
+              pendingOwner: null, // no pending owner
+            },
+          },
+          code.counter,
         ),
       ),
     }
@@ -168,7 +183,7 @@ describe('MCMS - ManyChainMultiSigSubgroupsTest', () => {
         chainId: MCMSBaseTestSetup.TEST_CHAIN_ID,
         multiSig: bind.mcms.address,
         nonce: 1n,
-        to: bind.mcms.address, // TODO bind.counter.address,
+        to: bind.counter.address,
         value: toNano('0.1'),
         data: beginCell().storeUint(0xffffffff, 32).endCell(),
       },
@@ -302,7 +317,7 @@ describe('MCMS - ManyChainMultiSigSubgroupsTest', () => {
         chainId: MCMSBaseTestSetup.TEST_CHAIN_ID,
         multiSig: bind.mcms.address,
         nonce: BigInt(nonce),
-        to: bind.mcms.address, // TODO bind.counter.address,
+        to: bind.counter.address,
         value: toNano('0.1'),
         data: beginCell().storeUint(0xffffffff, 32).endCell(),
       },
@@ -336,7 +351,7 @@ describe('MCMS - ManyChainMultiSigSubgroupsTest', () => {
             chainId: MCMSBaseTestSetup.TEST_CHAIN_ID,
             multiSig: bind.mcms.address,
             nonce: BigInt(nonce),
-            to: bind.mcms.address, // TODO bind.counter.address,
+            to: bind.counter.address,
             value: toNano('0.1'),
             data: beginCell().storeUint(0xffffffff, 32).endCell(),
           },

--- a/contracts/tests/mcms/ManyChainMultiSigSubgroups.spec.ts
+++ b/contracts/tests/mcms/ManyChainMultiSigSubgroups.spec.ts
@@ -1,20 +1,11 @@
-import {
-  toNano,
-  beginCell,
-  Address,
-  Dictionary,
-  TransactionDescriptionGeneric,
-  TransactionComputeVm,
-} from '@ton/core'
+import { toNano, beginCell } from '@ton/core'
 import { Blockchain, SandboxContract, TreasuryContract } from '@ton/sandbox'
 import '@ton/test-utils'
-import { compile } from '@ton/blueprint'
 import { MCMSBaseTestSetup, MCMSTestCode, TestSigner } from './ManyChainMultiSigBaseTest'
 import { merkleProof } from '../../src/mcms'
 import * as mcms from '../../wrappers/mcms/MCMS'
-import { asSnakeData, uint8ArrayToBigInt } from '../../src/utils'
-import { KeyPair, keyPairFromSeed, sha256, sign } from '@ton/crypto'
-import { randomBytes } from 'crypto'
+import { uint8ArrayToBigInt } from '../../src/utils'
+import { sha256, sign } from '@ton/crypto'
 import { ocr } from '../../wrappers/libraries/ocr'
 import { generateEd25519KeyPair } from '../libraries/ocr/Helpers'
 
@@ -135,14 +126,8 @@ describe('MCMS - ManyChainMultiSigSubgroupsTest', () => {
     })
 
     // form a chain of groups from the last group to the root
-    const groupQuorums = Dictionary.empty<number, number>(
-      Dictionary.Keys.Uint(8),
-      Dictionary.Values.Uint(8),
-    )
-    const groupParents = Dictionary.empty<number, number>(
-      Dictionary.Keys.Uint(8),
-      Dictionary.Values.Uint(8),
-    )
+    const groupQuorums = new Map<number, number>()
+    const groupParents = new Map<number, number>()
 
     for (let i = 0; i < MCMS_NUM_GROUPS; i++) {
       if (i !== 0) {
@@ -158,14 +143,8 @@ describe('MCMS - ManyChainMultiSigSubgroupsTest', () => {
     {
       const setConfigBody = mcms.builder.message.in.setConfig.encode({
         queryId: 1n,
-        signerKeys: asSnakeData<bigint>(
-          testSigners.map((s) => BigInt('0x' + s.keyPair.publicKey.toString('hex'))),
-          (a) => beginCell().storeUint(a, 256),
-        ),
-        signerGroups: asSnakeData<number>(
-          testSigners.map((s) => s.group),
-          (g) => beginCell().storeUint(g, 8),
-        ),
+        signerKeys: testSigners.map((s) => BigInt('0x' + s.keyPair.publicKey.toString('hex'))),
+        signerGroups: testSigners.map((s) => s.group),
         groupQuorums,
         groupParents,
         clearRoot: false,
@@ -253,14 +232,8 @@ describe('MCMS - ManyChainMultiSigSubgroupsTest', () => {
     randomState: Buffer<ArrayBuffer>,
   ): Promise<Buffer<ArrayBuffer>> {
     const groupChildrenCounts = new Array(MCMS_NUM_GROUPS).fill(0)
-    const groupQuorums = Dictionary.empty<number, number>(
-      Dictionary.Keys.Uint(8),
-      Dictionary.Values.Uint(8),
-    )
-    const groupParents = Dictionary.empty<number, number>(
-      Dictionary.Keys.Uint(8),
-      Dictionary.Values.Uint(8),
-    )
+    const groupQuorums = new Map<number, number>()
+    const groupParents = new Map<number, number>()
 
     // Assign signers to random groups
     for (let i = 0; i < NUM_SIGNERS; i++) {
@@ -299,18 +272,12 @@ describe('MCMS - ManyChainMultiSigSubgroupsTest', () => {
 
     // Set configuration
     {
-      const signers = asSnakeData<bigint>(
-        testSigners.map((s) => BigInt('0x' + s.keyPair.publicKey.toString('hex'))),
-        (a) => beginCell().storeUint(a, 256),
-      )
+      const signers = testSigners.map((s) => BigInt('0x' + s.keyPair.publicKey.toString('hex')))
 
       const setConfigBody = mcms.builder.message.in.setConfig.encode({
         queryId: 1n,
         signerKeys: signers,
-        signerGroups: asSnakeData<number>(
-          testSigners.map((s) => s.group),
-          (g) => beginCell().storeUint(g, 8),
-        ),
+        signerGroups: testSigners.map((s) => s.group),
         groupQuorums,
         groupParents,
         clearRoot: false,
@@ -439,14 +406,8 @@ describe('MCMS - ManyChainMultiSigSubgroupsTest', () => {
     })
 
     // Create malformed group configuration (causes parent index issues)
-    const groupQuorums = Dictionary.empty<number, number>(
-      Dictionary.Keys.Uint(8),
-      Dictionary.Values.Uint(8),
-    )
-    const malformedGroupParents = Dictionary.empty<number, number>(
-      Dictionary.Keys.Uint(8),
-      Dictionary.Values.Uint(8),
-    )
+    const groupQuorums = new Map<number, number>()
+    const malformedGroupParents = new Map<number, number>()
 
     for (let i = 0; i < MCMS_NUM_GROUPS; i++) {
       groupQuorums.set(i, 1)
@@ -454,17 +415,11 @@ describe('MCMS - ManyChainMultiSigSubgroupsTest', () => {
       malformedGroupParents.set(i, i + 1)
     }
 
-    const signerGroupsData = asSnakeData<number>(
-      testSigners.map((s) => s.group),
-      (g) => beginCell().storeUint(g, 8),
-    )
+    const signerGroupsData = testSigners.map((s) => s.group)
     // Test malformed configuration should fail
     const malformedSetConfigBody = mcms.builder.message.in.setConfig.encode({
       queryId: 1n,
-      signerKeys: asSnakeData<bigint>(
-        testSigners.map((s) => BigInt('0x' + s.keyPair.publicKey.toString('hex'))),
-        (a) => beginCell().storeUint(a, 256),
-      ),
+      signerKeys: testSigners.map((s) => BigInt('0x' + s.keyPair.publicKey.toString('hex'))),
       signerGroups: signerGroupsData,
       groupQuorums,
       groupParents: malformedGroupParents,
@@ -485,10 +440,7 @@ describe('MCMS - ManyChainMultiSigSubgroupsTest', () => {
     })
 
     // Fix the group parent relationships
-    const correctGroupParents = Dictionary.empty<number, number>(
-      Dictionary.Keys.Uint(8),
-      Dictionary.Values.Uint(8),
-    )
+    const correctGroupParents = new Map<number, number>()
     correctGroupParents.set(0, 0) // Root parent is itself
     for (let i = 1; i < MCMS_NUM_GROUPS; i++) {
       correctGroupParents.set(i, i - 1) // Each group's parent is the previous one
@@ -496,10 +448,7 @@ describe('MCMS - ManyChainMultiSigSubgroupsTest', () => {
 
     const correctSetConfigBody = mcms.builder.message.in.setConfig.encode({
       queryId: 2n,
-      signerKeys: asSnakeData<bigint>(
-        testSigners.map((s) => BigInt('0x' + s.keyPair.publicKey.toString('hex'))),
-        (a) => beginCell().storeUint(a, 256),
-      ),
+      signerKeys: testSigners.map((s) => BigInt('0x' + s.keyPair.publicKey.toString('hex'))),
       signerGroups: signerGroupsData,
       groupQuorums,
       groupParents: correctGroupParents,

--- a/contracts/tests/mcms/RBACTimelockExecute.spec.ts
+++ b/contracts/tests/mcms/RBACTimelockExecute.spec.ts
@@ -516,8 +516,7 @@ describe('MCMS - RBACTimelockExecuteTest', () => {
     }
   })
 
-  // TODO test Callproxy first')
-  describe.skip('Call Proxy Execute Tests', () => {
+  describe('Call Proxy Execute Tests', () => {
     it('should execute through valid call proxy', async () => {
       const incrementCall: rbactl.Call = {
         target: baseTest.bind.counter.address,
@@ -545,17 +544,7 @@ describe('MCMS - RBACTimelockExecuteTest', () => {
       baseTest.warpTime(Number(BaseTestSetup.MIN_DELAY + 1n))
 
       // Grant executor role to call proxy
-      const grantRoleBody = ac.builder.message.in.grantRole.encode({
-        queryId: 1n,
-        role: rbactl.roles.executor,
-        account: baseTest.bind.callProxy.address,
-      })
-
-      await baseTest.bind.ac.sendInternal(
-        baseTest.acc.admin.getSender(),
-        toNano('0.05'),
-        grantRoleBody,
-      )
+      await baseTest.grantCallProxyExecutorRole()
 
       // Execute through call proxy using external caller
       const executeBody = rbactl.builder.message.in.executeBatch.encode({

--- a/contracts/wrappers/libraries/access/Ownable2Step.ts
+++ b/contracts/wrappers/libraries/access/Ownable2Step.ts
@@ -11,6 +11,12 @@ import {
 import { crc32 } from 'zlib'
 import { CellCodec } from '../../utils'
 
+export enum Errors {
+  OnlyCallableByOwner = 132,
+  CannotTransferToSelf = 1001,
+  MustBeProposedOwner = 1002,
+}
+
 // @dev Message sent by the owner to transfer ownership of a contract.
 export type TransferOwnership = {
   // Query ID of the change owner request.

--- a/contracts/wrappers/mcms/MCMS.ts
+++ b/contracts/wrappers/mcms/MCMS.ts
@@ -6,13 +6,15 @@ import {
   contractAddress,
   ContractProvider,
   Dictionary,
+  DictionaryKeyTypes,
   Sender,
   SendMode,
 } from '@ton/core'
 import { crc32 } from 'zlib'
 import { CellCodec, sha256_32 } from '../utils'
-import { ZERO_ADDRESS } from '../../src/utils'
+import { asSnakeData, fromSnakeData, ZERO_ADDRESS } from '../../src/utils'
 import * as ownable2step from '../libraries/access/Ownable2Step'
+import { loadDict, loadMap } from '../../src/utils/dict'
 
 // @dev Top up contract with TON coins.
 export type TopUp = {
@@ -54,13 +56,13 @@ export type SetConfig = {
   queryId: bigint
 
   // List of signer public keys.
-  signerKeys: Cell // vec<uint256>
+  signerKeys: bigint[] // vec<uint256>
   // List of signer groups.
-  signerGroups: Cell // vec<uint8>
+  signerGroups: number[] // vec<uint8>
   // List of group quorums.
-  groupQuorums: Dictionary<number, number> // map<uint8, uint8> (indexed, iterable backwards)
+  groupQuorums: Map<number, number> // map<uint8, uint8> (indexed, iterable backwards)
   // List of group parents.
-  groupParents: Dictionary<number, number> // map<uint8, uint8> (indexed, iterable backwards)
+  groupParents: Map<number, number> // map<uint8, uint8> (indexed, iterable backwards)
   // Whether to clear the current root.
   clearRoot: boolean
 }
@@ -76,12 +78,12 @@ export type ContractData = {
   /// Ownable trait data
   ownable: ownable2step.Data
   /// Map where entry exists if the public key is a signer
-  signers: Dictionary<bigint, Buffer> // map<uint256, Signer>
+  signers: Map<bigint, Buffer> // map<uint256, Signer>
   /// The current configuration of the contract
   config: Config
 
   /// Remember signedHashes that this contract has seen. Each signedHash can only be set once.
-  seenSignedHashes: Dictionary<bigint, boolean> // map<uint256, bool>
+  seenSignedHashes: Map<bigint, boolean> // map<uint256, bool>
   /// The current expiring root and the number of ops in it.
   expiringRootAndOpCount: ExpiringRootAndOpCount
   /// The current metadata about the root.
@@ -247,17 +249,17 @@ export type Signer = {
 // Configuration structure for the contract
 export type Config = {
   // Map of signer indices to Signer objects (indexed)
-  signers: Dictionary<number, Buffer> // map<uint8, Signer> - (indexed)
+  signers: Map<number, Buffer> // map<uint8, Signer> - (indexed)
   // groupQuorums[i] stores the quorum for the i-th signer group. Any group with
   // groupQuorums[i] = 0 is considered disabled. The i-th group is successful if
   // it is enabled and at least groupQuorums[i] of its children are successful.
-  groupQuorums: Dictionary<number, number> // map<uint8, uint8> (indexed, iterable backwards)
+  groupQuorums: Map<number, number> // map<uint8, uint8> (indexed, iterable backwards)
   // groupParents[i] stores the parent group of the i-th signer group. We ensure that the
   // groups form a tree structure (where the root/0-th signer group points to itself as
   // parent) by enforcing:
   // - (i != 0) implies (groupParents[i] < i)
   // - groupParents[0] == 0
-  groupParents: Dictionary<number, number> // map<uint8, uint8> (indexed, iterable backwards)
+  groupParents: Map<number, number> // map<uint8, uint8> (indexed, iterable backwards)
 }
 
 /// MerkleRoots are a bit tricky since they reveal almost no information about the contents of
@@ -442,10 +444,14 @@ export const builder = {
           return beginCell()
             .storeUint(opcodes.in.SetConfig, 32)
             .storeUint(msg.queryId, 64)
-            .storeRef(msg.signerKeys)
-            .storeRef(msg.signerGroups)
-            .storeDict(msg.groupQuorums)
-            .storeDict(msg.groupParents)
+            .storeRef(asSnakeData<bigint>(msg.signerKeys, (a) => beginCell().storeUint(a, 256)))
+            .storeRef(asSnakeData<number>(msg.signerGroups, (g) => beginCell().storeUint(g, 8)))
+            .storeDict(
+              loadMap(Dictionary.Keys.Uint(8), Dictionary.Values.Uint(8), msg.groupQuorums),
+            )
+            .storeDict(
+              loadMap(Dictionary.Keys.Uint(8), Dictionary.Values.Uint(8), msg.groupParents),
+            )
             .storeBit(msg.clearRoot)
             .endCell()
         },
@@ -454,19 +460,23 @@ export const builder = {
           s.skip(32) // skip opcode
           return {
             queryId: s.loadUintBig(64),
-            signerKeys: s.loadRef(),
-            signerGroups: s.loadRef(),
-            groupQuorums: Dictionary.loadDirect(
-              Dictionary.Keys.Uint(8),
-              Dictionary.Values.Uint(8),
-              s.loadRef(),
+            signerKeys: fromSnakeData<bigint>(s.loadRef(), (a) => a.loadUintBig(256)),
+            signerGroups: fromSnakeData<number>(s.loadRef(), (g) => g.loadUint(8)),
+            groupQuorums: loadDict(
+              Dictionary.loadDirect(
+                Dictionary.Keys.Uint(8),
+                Dictionary.Values.Uint(8),
+                s.loadRef(),
+              ),
             ),
-            groupParents: Dictionary.loadDirect(
-              Dictionary.Keys.Uint(8),
-              Dictionary.Values.Uint(8),
-              s.loadRef(),
+            groupParents: loadDict(
+              Dictionary.loadDirect(
+                Dictionary.Keys.Uint(8),
+                Dictionary.Values.Uint(8),
+                s.loadRef(),
+              ),
             ),
-            clearRoot: s.loadBoolean(), // boolean
+            clearRoot: s.loadBoolean(),
           }
         },
       },
@@ -475,33 +485,42 @@ export const builder = {
   data: (() => {
     const config: CellCodec<Config> = {
       encode: (data: Config): Cell => {
+        const signers = loadMap(
+          Dictionary.Keys.Uint(8),
+          Dictionary.Values.Buffer(LEN_SIGNER_BYTES),
+          data.signers,
+        )
+        const groupQuorums = loadMap(
+          Dictionary.Keys.Uint(8),
+          Dictionary.Values.Uint(8),
+          data.groupQuorums,
+        )
+        const groupParents = loadMap(
+          Dictionary.Keys.Uint(8),
+          Dictionary.Values.Uint(8),
+          data.groupParents,
+        )
         return beginCell()
-          .storeDict(
-            data.signers,
-            Dictionary.Keys.Uint(8),
-            Dictionary.Values.Buffer(LEN_SIGNER_BYTES),
-          )
-          .storeDict(data.groupQuorums, Dictionary.Keys.Uint(8), Dictionary.Values.Uint(8))
-          .storeDict(data.groupParents, Dictionary.Keys.Uint(8), Dictionary.Values.Uint(8))
+          .storeDict(signers, Dictionary.Keys.Uint(8), Dictionary.Values.Buffer(LEN_SIGNER_BYTES))
+          .storeDict(groupQuorums, Dictionary.Keys.Uint(8), Dictionary.Values.Uint(8))
+          .storeDict(groupParents, Dictionary.Keys.Uint(8), Dictionary.Values.Uint(8))
           .endCell()
       },
       decode: (cell: Cell): Config => {
         const s = cell.beginParse()
         return {
-          signers: Dictionary.loadDirect(
-            Dictionary.Keys.Uint(8),
-            Dictionary.Values.Buffer(LEN_SIGNER_BYTES),
-            s.loadRef(),
+          signers: loadDict(
+            Dictionary.loadDirect(
+              Dictionary.Keys.Uint(8),
+              Dictionary.Values.Buffer(LEN_SIGNER_BYTES),
+              s.loadRef(),
+            ),
           ),
-          groupQuorums: Dictionary.loadDirect(
-            Dictionary.Keys.Uint(8),
-            Dictionary.Values.Uint(8),
-            s.loadRef(),
+          groupQuorums: loadDict(
+            Dictionary.loadDirect(Dictionary.Keys.Uint(8), Dictionary.Values.Uint(8), s.loadRef()),
           ),
-          groupParents: Dictionary.loadDirect(
-            Dictionary.Keys.Uint(8),
-            Dictionary.Values.Uint(8),
-            s.loadRef(),
+          groupParents: loadDict(
+            Dictionary.loadDirect(Dictionary.Keys.Uint(8), Dictionary.Values.Uint(8), s.loadRef()),
           ),
         }
       },
@@ -591,20 +610,27 @@ export const builder = {
         let _pendingOwnerMaybe = data.ownable.pendingOwner
           ? beginCell().storeAddress(data.ownable.pendingOwner)
           : null
-        let ownable = beginCell()
-          .storeAddress(data.ownable.owner)
-          .storeMaybeBuilder(_pendingOwnerMaybe)
 
         return beginCell()
           .storeUint(data.id, 32)
-          .storeBuilder(ownable)
+          .storeBuilder(
+            beginCell().storeAddress(data.ownable.owner).storeMaybeBuilder(_pendingOwnerMaybe),
+          )
           .storeDict(
-            data.signers,
+            loadMap(
+              Dictionary.Keys.BigUint(256),
+              Dictionary.Values.Buffer(LEN_SIGNER_BYTES),
+              data.signers,
+            ),
             Dictionary.Keys.BigUint(256),
             Dictionary.Values.Buffer(LEN_SIGNER_BYTES),
           )
           .storeRef(config.encode(data.config))
-          .storeDict(data.seenSignedHashes, Dictionary.Keys.BigUint(256), Dictionary.Values.Bool())
+          .storeDict(
+            loadMap(Dictionary.Keys.BigUint(256), Dictionary.Values.Bool(), data.seenSignedHashes),
+            Dictionary.Keys.BigUint(256),
+            Dictionary.Values.Bool(),
+          )
           .storeBuilder(expiringRootAndOpCount.encode(data.expiringRootAndOpCount).asBuilder())
           .storeRef(rootMetadata.encode(data.rootMetadata))
           .endCell()
@@ -618,18 +644,22 @@ export const builder = {
           pendingOwner: s.loadAddress(),
         }
 
-        const signers = Dictionary.loadDirect(
-          Dictionary.Keys.BigUint(256),
-          Dictionary.Values.Buffer(LEN_SIGNER_BYTES),
-          s.loadRef(),
+        const signers = loadDict(
+          Dictionary.loadDirect(
+            Dictionary.Keys.BigUint(256),
+            Dictionary.Values.Buffer(LEN_SIGNER_BYTES),
+            s.loadRef(),
+          ),
         )
 
         const _config = config.decode(s.loadRef())
 
-        const seenSignedHashes = Dictionary.loadDirect(
-          Dictionary.Keys.BigUint(256),
-          Dictionary.Values.Bool(),
-          s.loadRef(),
+        const seenSignedHashes = loadDict(
+          Dictionary.loadDirect(
+            Dictionary.Keys.BigUint(256),
+            Dictionary.Values.Bool(),
+            s.loadRef(),
+          ),
         )
 
         const expiringRootAndOpCount = {
@@ -658,40 +688,20 @@ export const builder = {
       },
     }
 
-    const contractDataEmpty = (id: number, owner: Address) => {
+    const contractDataEmpty = (id: number, owner: Address): ContractData => {
       return {
         id, // unique ID for this instance
         ownable: {
           owner,
           pendingOwner: null, // no pending owner
         },
-        signers: Dictionary.empty(
-          // no signers
-          Dictionary.Keys.BigUint(256),
-          Dictionary.Values.Buffer(LEN_SIGNER_BYTES),
-        ),
+        signers: new Map<bigint, Buffer>(),
         config: {
-          signers: Dictionary.empty(
-            // no signers
-            Dictionary.Keys.Uint(8),
-            Dictionary.Values.Buffer(LEN_SIGNER_BYTES),
-          ),
-          groupQuorums: Dictionary.empty(
-            // no group quorums
-            Dictionary.Keys.Uint(8),
-            Dictionary.Values.Uint(8),
-          ),
-          groupParents: Dictionary.empty(
-            // no group parents
-            Dictionary.Keys.Uint(8),
-            Dictionary.Values.Uint(8),
-          ),
+          signers: new Map<number, Buffer>(),
+          groupQuorums: new Map<number, number>(),
+          groupParents: new Map<number, number>(),
         },
-        seenSignedHashes: Dictionary.empty(
-          // no seen signed hashes
-          Dictionary.Keys.BigUint(256),
-          Dictionary.Values.Bool(),
-        ),
+        seenSignedHashes: new Map<bigint, boolean>(),
         expiringRootAndOpCount: {
           root: 0n, // no root
           validUntil: 0n, // no validity
@@ -771,20 +781,26 @@ export class ContractClient implements Contract {
   async getConfig(p: ContractProvider): Promise<Config> {
     return p.get('getConfig', []).then((r) => {
       return {
-        signers: Dictionary.loadDirect(
-          Dictionary.Keys.Uint(8),
-          Dictionary.Values.Buffer(LEN_SIGNER_BYTES),
-          r.stack.readCell(),
+        signers: loadDict(
+          Dictionary.loadDirect(
+            Dictionary.Keys.Uint(8),
+            Dictionary.Values.Buffer(LEN_SIGNER_BYTES),
+            r.stack.readCell(),
+          ),
         ),
-        groupQuorums: Dictionary.loadDirect(
-          Dictionary.Keys.Uint(8),
-          Dictionary.Values.Uint(8),
-          r.stack.readCell(),
+        groupQuorums: loadDict(
+          Dictionary.loadDirect(
+            Dictionary.Keys.Uint(8),
+            Dictionary.Values.Uint(8),
+            r.stack.readCell(),
+          ),
         ),
-        groupParents: Dictionary.loadDirect(
-          Dictionary.Keys.Uint(8),
-          Dictionary.Values.Uint(8),
-          r.stack.readCell(),
+        groupParents: loadDict(
+          Dictionary.loadDirect(
+            Dictionary.Keys.Uint(8),
+            Dictionary.Values.Uint(8),
+            r.stack.readCell(),
+          ),
         ),
       }
     })

--- a/contracts/wrappers/mcms/MCMS.ts
+++ b/contracts/wrappers/mcms/MCMS.ts
@@ -47,7 +47,7 @@ export type Execute = {
   // The operation to be executed, stored as a Cell to avoid size limits.
   op: Cell // Cell<Op>
   // The Merkle proof for the op's inclusion in the Merkle tree.
-  proof: Cell // vec<uint256>
+  proof: bigint[] // vec<uint256>
 }
 
 // @dev Sets the configuration for the contract.
@@ -425,7 +425,7 @@ export const builder = {
             .storeUint(opcodes.in.Execute, 32)
             .storeUint(msg.queryId, 64)
             .storeRef(msg.op)
-            .storeRef(msg.proof)
+            .storeRef(asSnakeData<bigint>(msg.proof, (v) => beginCell().storeUint(v, 256)))
             .endCell()
         },
         decode: (cell: Cell): Execute => {
@@ -434,7 +434,7 @@ export const builder = {
           return {
             queryId: s.loadUintBig(64),
             op: s.loadRef(),
-            proof: s.loadRef(),
+            proof: fromSnakeData(s.loadRef(), (a) => a.loadUintBig(256)),
           }
         },
       },


### PR DESCRIPTION
- [x] fix codec leaking (TON Dictinaries and snakeData)
- [x] expose error codes for ownable2Step
- [x] interface to structs on base test
- [x] RBACTimelockExecuteTest: execute through call proxy