### PR TITLE
Add support for mcms.tolk execution bounces

### DIFF
--- a/contracts/contracts/lib/access/access_control.tolk
+++ b/contracts/contracts/lib/access/access_control.tolk
@@ -54,7 +54,7 @@ import "../utils.tolk";
 /// May send a {AccessControl_RoleGranted} message.
 ///
 struct (0x95cd540f) AccessControl_GrantRole {
-    /// Query ID of the change owner request.
+    /// Query ID of the change request.
     queryId: uint64;
 
     /// Role definition.
@@ -74,7 +74,7 @@ struct (0x95cd540f) AccessControl_GrantRole {
 /// May send a {AccessControl_RoleRevoked} message.
 ///
 struct (0x969b0db9) AccessControl_RevokeRole {
-    /// Query ID of the change owner request.
+    /// Query ID of the change request.
     queryId: uint64;
 
     /// Role definition.
@@ -99,7 +99,7 @@ struct (0x969b0db9) AccessControl_RevokeRole {
 /// May send a {AccessControl_RoleRevoked} message.
 ///
 struct (0x39452c46) AccessControl_RenounceRole {
-    /// Query ID of the change owner request.
+    /// Query ID of the change request.
     queryId: uint64;
 
     /// Role definition.
@@ -121,7 +121,7 @@ type AccessControl_InMessage = AccessControl_GrantRole
 /// Expected in cases where the role was granted using the internal {AccessControl-_grantRole}.
 ///
 struct (0xcf3ca837) AccessControl_RoleGranted {
-    /// Query ID of the change owner request.
+    /// Query ID of the change request.
     queryId: uint64;
 
     /// Role definition.
@@ -139,7 +139,7 @@ struct (0xcf3ca837) AccessControl_RoleGranted {
 /// - if using `renounceRole`, it is the role bearer (i.e. `account`)
 ///
 struct (0x990fe1c7) AccessControl_RoleRevoked {
-    /// Query ID of the change owner request.
+    /// Query ID of the change request.
     queryId: uint64;
 
     /// Role definition.
@@ -156,7 +156,7 @@ struct (0x990fe1c7) AccessControl_RoleRevoked {
 /// {AccessControl_RoleAdminChanged} not being sent to signal this.
 ///
 struct (0xbd7e8bce) AccessControl_RoleAdminChanged {
-    /// Query ID of the change owner request.
+    /// Query ID of the change request.
     queryId: uint64;
 
     /// Role definition.

--- a/contracts/contracts/lib/utils.tolk
+++ b/contracts/contracts/lib/utils.tolk
@@ -12,6 +12,12 @@ const ERROR_BITMAP_OUT_OF_BOUNDS = 0x78;
 /// the full excess value.
 const DEFAULT_MESSAGE_BUDGET_FEE = ton("0.01");
 
+/// Maximum size of a bounced message
+///
+/// Notice: documentation for in.bouncedBody is off, as it states the bounced body
+/// will be 0xffffffff + 224 bits, but the actual size is 0xffffffff + 256 bits.
+const BOUNCE_MSG_SIZE_MAX = 256;
+
 /// Returns the global ID of the current blockchain (chain ID).
 fun globalId(): int {
     // Notice: configParam(19)! will be available (non-null)
@@ -20,8 +26,10 @@ fun globalId(): int {
 
 /// Extracts the (potential) bounced body from the given slice (message body).
 fun extractBouncedBody(body: slice): uint256 {
-    val bits = body.remainingBitsCount();
-    return bits < 256 ? body.loadUint(bits) : body.loadUint(256);
+    val remainingBits = body.remainingBitsCount();
+    return remainingBits < BOUNCE_MSG_SIZE_MAX
+        ? body.loadUint(remainingBits)
+        : body.loadUint(BOUNCE_MSG_SIZE_MAX);
 }
 
 /// Computes the Keccak-256 hash of the given data.

--- a/contracts/contracts/lib/utils.tolk
+++ b/contracts/contracts/lib/utils.tolk
@@ -6,11 +6,25 @@ const ERROR_INVALID_DATA = 0x77;
 const ERROR_BITMAP_OUT_OF_BOUNDS = 0x78;
 
 /// TODO: is this enough? do we make this configurable?
+/// TODO: replace with more dynamic DEFAULT_MESSAGE_FWD_BUDGET_GAS_UNITS + calculateGasFee
 ///
 /// The default message budget fee for messages (replies, notifications),
 /// for which the value is not explicitly set, and we're not sending
 /// the full excess value.
 const DEFAULT_MESSAGE_BUDGET_FEE = ton("0.01");
+
+/// The default message forwarding budget fee for messages (replies, notifications, sends)
+/// in gas units. The expectation is this is enough to cover the basic transaction costs
+/// for the recipient, at least validation and bounces, to avoid out of gas errors (no bounces).
+///
+/// TL;DR: Today (Q3/25), a basic transaction costs about 0.0025 TON.
+/// Current settings in basechain are as follows: 1 unit of gas costs 400 nanotons.
+/// Source: https://docs.ton.org/v3/documentation/smart-contracts/transaction-fees/fees
+///
+/// For comparison, the Jetton contract requires at least 21k gas units + fwd_fee + storage_fee
+/// to cover the token transaction costs.
+///
+const DEFAULT_MESSAGE_FWD_BUDGET_GAS_UNITS = 30000;  // 0.012 TON at 400 nanotons/unit
 
 /// Maximum size of a bounced message
 ///

--- a/contracts/contracts/lib/utils.tolk
+++ b/contracts/contracts/lib/utils.tolk
@@ -18,6 +18,12 @@ fun globalId(): int {
     return blockchain.configParam(19)!.beginParse().loadInt(32);
 }
 
+/// Extracts the (potential) bounced body from the given slice (message body).
+fun extractBouncedBody(body: slice): uint256 {
+    val bits = body.remainingBitsCount();
+    return bits < 256 ? body.loadUint(bits) : body.loadUint(256);
+}
+
 /// Computes the Keccak-256 hash of the given data.
 @pure
 fun keccak256(data: slice): uint256

--- a/contracts/contracts/mcms/call_proxy.tolk
+++ b/contracts/contracts/mcms/call_proxy.tolk
@@ -6,7 +6,7 @@ tolk 1.0
 /// Contract might receive/hold TON as part of the maintenance process.
 ///
 struct (0x3b3d63b8) CallProxy_TopUp {
-    /// Query ID of the change owner request.
+    /// Query ID of the change request.
     queryId: uint64;
 }
 

--- a/contracts/contracts/mcms/mcms.tolk
+++ b/contracts/contracts/mcms/mcms.tolk
@@ -138,7 +138,7 @@ struct (0x89277f4b) MCMS_SetConfig {
 ///
 /// @dev The error oracle can only report errors for the current non-expired root, to avoid reporting
 /// stale errors for operations that are no longer valid.
-struct (0x43ebc734) MCMS_SubmitErrorReport {
+struct (0x4b3af0b5) MCMS_SubmitErrorReport {
     /// Query ID of the change request.
     queryId: uint64;
 
@@ -217,7 +217,7 @@ struct (0x7cf37cbf) MCMS_OpExecuted {
 }
 
 /// Sent back to sender when an error report is successfully submitted.
-struct (0x43ebc734) MCMS_ErrorReportSubmitted {
+struct (0xbbc4deb4) MCMS_ErrorReportSubmitted {
     /// Query ID of the change request.
     queryId: uint64;
 
@@ -862,7 +862,7 @@ fun MCMS<T>.execute(
         throw ERROR_WRONG_MULTI_SIG;
     }
 
-    if (blockchain.now() > currentExpiringRootAndOpCount.validUntil) {
+    if (blockchain.now() >= currentExpiringRootAndOpCount.validUntil) {
         throw ERROR_ROOT_EXPIRED;
     }
 

--- a/contracts/contracts/mcms/mcms.tolk
+++ b/contracts/contracts/mcms/mcms.tolk
@@ -209,7 +209,7 @@ struct MCMS_Data {
     /// Remember signedHashes that this contract has seen. Each signedHash can only be set once.
     seenSignedHashes: dict; // map<uint256, bool>
     /// The current expiring root and the number of ops in it.
-    expiringRootAndOpCount: ExpiringRootAndOpCount;
+    expiringRootAndOpCount: ExpiringRootAndOpCount; // TODO: Error: contracts/mcms/mcms.tolk:195: error: struct `MCMS_Data` can exceed 1023 bits in serialization (estimated size: 687..1484 bits)
     /// The current metadata about the root.
     rootMetadata: Cell<RootMetadata>; // Notice: split out as cell to avoid size limits
 }
@@ -250,6 +250,8 @@ const MANY_CHAIN_MULTI_SIG_DOMAIN_SEPARATOR_METADATA =
 
 const NUM_GROUPS = 32;
 const MAX_NUM_SIGNERS = 200;
+
+const DEFAULT_FINALIZATION_TIMEOUT = 60; // in seconds
 
 /// @notice Thrown when number of signers is 0 or greater than MAX_NUM_SIGNERS.
 const ERROR_OUT_OF_BOUNDS_NUM_SIGNERS = 100;
@@ -322,6 +324,9 @@ const ERROR_MISSING_CONFIG = 120;
 
 /// @notice Thrown when attempt to set the same (root, validUntil) in setRoot().
 const ERROR_SIGNED_HASH_ALREADY_SEEN = 121;
+
+/// @notice Thrown when the root has not been finalized yet (can't execute next op before finalization).
+const ERROR_ROOT_NOT_FINALIZED = 122;
 
 // --- Constants - storage ---
 
@@ -414,6 +419,20 @@ struct ExpiringRootAndOpCount {
     validUntil: uint32;
     /// each ManyChainMultiSig instance has it own independent opCount.
     opCount: uint40;
+
+    /// TON-specific additions below to support the async environment
+    ///
+    /// The time at which the root becomes valid [executionTime(opCount - 1) + opFinalizationTimeout].
+    /// At this time the previous executed operation is considered optimistically final and succesfull,
+    /// meaning no bounce was received and we can continue executing.
+    validAfter: uint32;
+    /// The timeout required to finalize the currently executing op
+    opFinalizationTimeout: uint32;
+    /// The address that the (pending) operation was sent to (and could bounce from).
+    opPendingReceiver: address;
+    /// The truncated body of the pending operation (256 bits from the original message),
+    /// stored as the next expected potential bounce, and verified in onBounceMessage handler.
+    opPendingBodyVal: uint256;
 }
 
 /// @notice Each root also authenticates metadata about itself (stored as one of the leaves)
@@ -504,7 +523,8 @@ fun MCMS<T>.setRoot(
     validUntil: uint32,
     metadata: RootMetadata,
     metadataProof: Iterator<uint256>,
-    signatures: cell // vec<Signature>
+    signatures: cell, // vec<Signature>
+    opFinalizationTimeout: uint32 = DEFAULT_FINALIZATION_TIMEOUT
 ) {
     /// Construct the message that should be signed by the signers.
     val signedHash = beginCell()
@@ -680,9 +700,14 @@ fun MCMS<T>.setRoot(
     // done with validation, persist in in contract state
     self.data.seenSignedHashes.uDictSet(256, signedHash, createEmptySlice());
     self.data.expiringRootAndOpCount = ExpiringRootAndOpCount{
-        root: root,
-        validUntil: validUntil,
-        opCount: metadata.preOpCount
+        root,
+        validUntil,
+        opCount: metadata.preOpCount,
+        // TON-specific additions below to support the async environment
+        validAfter: blockchain.now(), // immediate
+        opFinalizationTimeout,
+        opPendingReceiver: createAddressNone(),
+        opPendingBodyVal: 0,
     };
     self.data.rootMetadata = metadata.toCell();
 
@@ -741,6 +766,10 @@ fun MCMS<T>.execute(
         throw ERROR_ROOT_EXPIRED;
     }
 
+    if (blockchain.now() < currentExpiringRootAndOpCount.validAfter) {
+        throw ERROR_ROOT_NOT_FINALIZED;
+    }
+
     if (op.nonce != currentExpiringRootAndOpCount.opCount) {
         throw ERROR_WRONG_NONCE;
     }
@@ -760,6 +789,19 @@ fun MCMS<T>.execute(
 
     // increase the counter *before* execution to prevent reentrancy issues
     self.data.expiringRootAndOpCount.opCount = currentExpiringRootAndOpCount.opCount + 1;
+
+    // Notice: we set optimistic finalization of an async operation using a timeout
+    // Within that timeout executions are paused as we wait for the finalization signal
+    //
+    // To finalize an execution, one of two conditions must be met:
+    // 1. Finalization timeout expired (can continue)
+    // 2. Message bounced back         (can retry)
+    self.data.expiringRootAndOpCount.validAfter =
+        blockchain.now() + self.data.expiringRootAndOpCount.opFinalizationTimeout;
+
+    // Store the pending message info (checked onBouncedMessage)
+    self.data.expiringRootAndOpCount.opPendingReceiver = op.to;
+    self.data.expiringRootAndOpCount.opPendingBodyVal = extractBouncedBody(op.data.beginParse());
 
     self._execute(op.to, op.value, op.data);
 
@@ -953,7 +995,12 @@ fun MCMS<T>.setConfig(
         self.data.expiringRootAndOpCount = ExpiringRootAndOpCount{
             root: 0, // empty root
             validUntil: 0,
-            opCount: opCount
+            opCount: opCount,
+            // TON-specific additions below to support the async environment
+            validAfter: blockchain.now(), // immediate
+            opFinalizationTimeout: 0,
+            opPendingReceiver: createAddressNone(),
+            opPendingBodyVal: 0
         };
         self.data.rootMetadata = RootMetadata{
             chainId: globalId() as int256,
@@ -1024,6 +1071,7 @@ fun MCMS<T>.onInternalMessage(mutate self, msgSender: address, msgValue: coins, 
             return;
         }
         MCMS_SetRoot => {
+            // TODO: make opFinalizationTimeout configurable
             self.setRoot(msgSender, msg.queryId, msg.root, msg.validUntil, msg.metadata,
                 Iterator<uint256>.new(msg.metadataProof), msg.signatures);
         }
@@ -1047,13 +1095,58 @@ fun MCMS<T>.onInternalMessage(mutate self, msgSender: address, msgValue: coins, 
     }
 }
 
-// TODO: handle bounced messages
+fun onBouncedMessage(in: InMessageBounced) {
+    // Load the contract storage as MCMS and handle the bounced message
+    var mcms = MCMS<bool>.load();
+
+    // If the op was already finalized, we need to drop the bounce, and mark the root invalid.
+    //
+    // This is because subsequent operations might already be executed, and we're not at the
+    // right index in the op sequence to be able to retry the (current) op.
+    //
+    // This is why critical operation sequences need to be commited with a timeout
+    // which will allow enough time for them to be bounced and subsequently retried.
+    if (mcms.data.expiringRootAndOpCount.validAfter < blockchain.now()) {
+        // TODO: maybe we can also store and check opCount to see if subsequent ops were executed in the meantime
+        mcms.data.expiringRootAndOpCount.validUntil = blockchain.now(); // expire root immediately
+        mcms.data.storeAsContractData();
+        return;
+    }
+
+    // Check the bounced message against the stored pending operation
+    // If the received bounce does NOT equal expected, mark the root invalid.
+    val bouncedBodyVal = extractBouncedBody(in.bouncedBody.skipBouncedPrefix());
+    if (mcms.data.expiringRootAndOpCount.opPendingReceiver != in.senderAddress 
+        || mcms.data.expiringRootAndOpCount.opPendingBodyVal != bouncedBodyVal) {
+        // Mark root in error state (recover with new root + bypass)
+        mcms.data.expiringRootAndOpCount.validUntil = blockchain.now(); // expire root immediately
+        mcms.data.storeAsContractData();
+        return;
+    }
+
+    // TODO!
+    //
+    // Check for edge case where the root is updated before an execution from
+    // a previous root bounced back. We drop late bounces if we have a fresh root.
+    // val rootMetadata = lazy RootMetadata.fromCell(mcms.data.rootMetadata);
+    // if (rootMetadata.preOpCount == mcms.data.expiringRootAndOpCount.opCount) {
+    //     return;
+    // }
+
+    // If the received bounce equals expected, revert state (allow op retry)
+    mcms.data.expiringRootAndOpCount.opCount = mcms.data.expiringRootAndOpCount.opCount - 1;
+    mcms.data.expiringRootAndOpCount.validAfter = blockchain.now(); // can be retried immediately
+    mcms.data.expiringRootAndOpCount.opPendingReceiver = createAddressNone();
+    mcms.data.expiringRootAndOpCount.opPendingBodyVal = 0;
+    mcms.data.storeAsContractData();
+}
+
 fun onInternalMessage(in: InMessage) {
-    /// Load the contract storage as MCMS and handle the message
+    // Load the contract storage as MCMS and handle the message
     var mcms = MCMS<bool>.load();
     mcms.onInternalMessage(in.senderAddress, in.valueCoins, in.body);
 
-    /// Store the updated contract data
+    // Store the updated contract data
     mcms.data.storeAsContractData();
 }
 

--- a/contracts/contracts/mcms/mcms.tolk
+++ b/contracts/contracts/mcms/mcms.tolk
@@ -237,7 +237,7 @@ struct (0xbbc4deb4) MCMS_ErrorReportSubmitted {
     matchesPendingOp: bool;
 }
 
-/// Event emitted by the contract when the oracle role is transferred.
+/// Sent back to sender when the oracle role is transferred.
 struct (0xff4176a3) MCMS_OracleRoleTransferred {
     /// Query ID of the change request.
     queryId: uint64;

--- a/contracts/contracts/mcms/mcms.tolk
+++ b/contracts/contracts/mcms/mcms.tolk
@@ -6,6 +6,7 @@ import "@stdlib/gas-payments";
 import "../lib/utils";
 import "../lib/access/ownable_2step.tolk";
 import "../lib/crypto/merkle_proof.tolk";
+import "../lib/ocr/exit_codes"
 
 /// This is a multi-sig contract that supports signing many transactions (called "ops" in
 /// the context of this contract to prevent confusion with transactions on the underlying chain)
@@ -251,6 +252,9 @@ struct MCMS_Data {
     /// Ownable trait data
     ownable: Ownable2Step;
 
+    /// Address of the error oracle account, which can submit error reports.
+    oracle: address;
+
     /// signers is used to easily validate the existence of the signer by its public key. We still
     /// have signers stored in config in order to easily deactivate them when a new config is set.
     signers: dict; // map<uint256, Signer> - exists if the public key is a signer
@@ -382,6 +386,9 @@ const ERROR_ROOT_NOT_FINALIZED = 122;
 
 /// Thrown when the provided op.value is insufficient (min required value not met).
 const ERROR_INSUFFICIENT_VALUE = 123;
+
+/// Thrown when the error report sender is not the authorized oracle.
+const ERROR_UNAUTHORIZED_ORACLE = 124;
 
 // --- Constants - storage ---
 
@@ -1134,9 +1141,10 @@ fun MCMS<T>.submitErrorReport(
     errorTxHash: uint256,
     errorCode: uint32
 ) {
-    // TODO: check oracle access
-
-    var rootInfo = lazy RootInfo.fromCell(self.data.rootInfo);
+    // Only the oracle can submit error reports
+    if (sender != self.data.oracle) {
+        throw ERROR_UNAUTHORIZED_ORACLE;
+    }
 
     // Check if right environment via chainId
     if (op.chainId != globalId() as int256) {
@@ -1146,6 +1154,8 @@ fun MCMS<T>.submitErrorReport(
     if (op.multiSig != contract.getAddress()) {
         throw ERROR_WRONG_MULTI_SIG;
     }
+
+    var rootInfo = lazy RootInfo.fromCell(self.data.rootInfo);
 
     if (blockchain.now() > rootInfo.expiringRootAndOpCount.validUntil) {
         throw ERROR_ROOT_EXPIRED;
@@ -1264,6 +1274,7 @@ fun MCMS<T>.onInternalMessage(mutate self, msgSender: address, msgValue: coins, 
             self.submitErrorReport(msgSender, msg.queryId, Op.fromCell(msg.op),
                 Iterator<uint256>.new(msg.proof), msg.opTxHash, msg.errorTxHash, msg.errorCode);
         }
+        // TODO: only owner should be able to update the error oracle
         else => {
             val msgHandled = 0
                 || self.data.ownable.onInternalMessage(msgSender, msgBody);

--- a/contracts/contracts/mcms/mcms.tolk
+++ b/contracts/contracts/mcms/mcms.tolk
@@ -7,7 +7,7 @@ import "../lib/utils";
 import "../lib/access/ownable_2step.tolk";
 import "../lib/crypto/merkle_proof.tolk";
 
-/// @notice This is a multi-sig contract that supports signing many transactions (called "ops" in
+/// This is a multi-sig contract that supports signing many transactions (called "ops" in
 /// the context of this contract to prevent confusion with transactions on the underlying chain)
 /// targeting many chains with a single set of signatures. Authorized ops along with some metadata
 /// are stored in a Merkle tree, which is generated offchain. Each op has an associated chain id,
@@ -35,15 +35,15 @@ import "../lib/crypto/merkle_proof.tolk";
 
 // --- Messages - incoming ---
 
-/// @dev Top up contract with TON coins.
-/// Contract might receive/hold TON as part of the maintenance process.
+/// Top up contract with TON coins.
 ///
+/// @dev Contract might receive/hold TON as part of the maintenance process.
 struct (0x5f427bb3) MCMS_TopUp {
-    /// Query ID of the change owner request.
+    /// Query ID of the change request.
     queryId: uint64;
 }
 
-/// @dev Sets a new expiring root.
+/// Sets a new expiring root.
 ///
 /// @param root is the new expiring root.
 /// @param validUntil is the time by which root is valid
@@ -58,7 +58,7 @@ struct (0x5f427bb3) MCMS_TopUp {
 /// @dev this method can be executed by anyone who has the root and valid signatures.
 /// as we validate the correctness of signatures, this imposes no risk.
 struct (0xe7fabde3) MCMS_SetRoot {
-    /// Query ID of the change owner request.
+    /// Query ID of the change request.
     queryId: uint64;
 
     /// The new expiring root.
@@ -76,7 +76,7 @@ struct (0xe7fabde3) MCMS_SetRoot {
     opFinalizationTimeout: uint32;
 }
 
-/// @notice Execute the received op after verifying the proof of its inclusion in the
+/// Execute the received op after verifying the proof of its inclusion in the
 /// current Merkle tree. The op should be the next op according to the order
 /// enforced by the merkle tree whose root is stored in data.rootInfo.expiringRootAndOpCount, i.e., the
 /// nonce of the op should be equal to data.rootInfo.expiringRootAndOpCount.opCount.
@@ -94,16 +94,16 @@ struct (0xe7fabde3) MCMS_SetRoot {
 /// @dev the gas limit of the call can be freely determined by the caller of this function.
 /// We expect callees to revert if they run out of gas.
 struct (0x9b9ce96a) MCMS_Execute {
-    /// Query ID of the change owner request.
+    /// Query ID of the change request.
     queryId: uint64;
 
     /// The op to be executed.
-    op: Cell<Op>; // Notice: split out as cell to avoid size limits
+    op: Cell<Op>; // @dev split out as cell to avoid size limits
     /// The MerkleProof for the op's inclusion in the MerkleTree
     proof: cell; // vec<uint256>,
 }
 
-/// @notice sets a new data.config. If clearRoot is true, then it also invalidates
+/// Sets a new data.config. If clearRoot is true, then it also invalidates
 /// data.rootInfo.expiringRootAndOpCount.root.
 ///
 /// @param signerKeys holds the public keys of the active signers. The keys must be in
@@ -121,7 +121,7 @@ struct (0x9b9ce96a) MCMS_Execute {
 /// might be used when the current root was signed under a loser group configuration or when
 /// some previous signers aren't trusted any more.
 struct (0x89277f4b) MCMS_SetConfig {
-    /// Query ID of the change owner request.
+    /// Query ID of the change request.
     queryId: uint64;
 
     signerKeys: cell;   // vec<uint256> (public keys)
@@ -131,18 +131,43 @@ struct (0x89277f4b) MCMS_SetConfig {
     clearRoot: bool;
 }
 
+/// Submit an oracle error report, which marks the current root as invalid.
+///
+/// The error report is used for a category of errors which might occur during execution
+/// of an operation, but can't be caught on-chain (OOG errors, and downstream tx-trace errors).
+///
+/// @dev The error oracle can only report errors for the current non-expired root, to avoid reporting
+/// stale errors for operations that are no longer valid.
+struct (0x43ebc734) MCMS_SubmitErrorReport {
+    /// Query ID of the change request.
+    queryId: uint64;
+
+    /// The operation which produced the error.
+    op: Cell<Op>;
+    /// The MerkleProof for the op's inclusion in the MerkleTree
+    proof: cell; // vec<uint256>,
+    /// The hash of the execute transaction.
+    opTxHash: uint256;
+
+    /// The hash of the transaction which errored (part of the tx trace).
+    errorTxHash: uint256;
+    /// The error code.
+    errorCode: uint32;
+}
+
 /// @dev Union of all incoming messages.
 type MCMS_InMessage =
     | MCMS_TopUp
     | MCMS_SetRoot
     | MCMS_Execute
-    | MCMS_SetConfig;
+    | MCMS_SetConfig
+    | MCMS_SubmitErrorReport;
 
 // --- Messages - outgoing ---
 
-/// @notice Emitted when a new root is set.
+/// Sent back to sender when a new root is set.
 struct (0xa6533a3d) MCMS_NewRoot {
-    /// Query ID of the change owner request.
+    /// Query ID of the change request.
     queryId: uint64;
 
     /// The new expiring root.
@@ -153,9 +178,9 @@ struct (0xa6533a3d) MCMS_NewRoot {
     metadata: RootMetadata;
 }
 
-/// @notice Emitted when a new config is set.
+/// Sent back to sender when a new config is set.
 struct (0xd80be574) MCMS_ConfigSet {
-    /// Query ID of the change owner request.
+    /// Query ID of the change request.
     queryId: uint64;
 
     /// The new config.
@@ -164,9 +189,9 @@ struct (0xd80be574) MCMS_ConfigSet {
     isRootCleared: bool;
 }
 
-/// @notice Emitted when an op gets successfully executed.
+/// Sent back to sender when an op gets successfully executed.
 struct (0x7cf37cbf) MCMS_OpExecuted {
-    /// Query ID of the change owner request.
+    /// Query ID of the change request.
     queryId: uint64;
 
     /// The nonce of the operation.
@@ -179,11 +204,33 @@ struct (0x7cf37cbf) MCMS_OpExecuted {
     value: coins;
 }
 
+/// Sent back to sender when an error report is successfully submitted.
+struct (0x43ebc734) MCMS_ErrorReportSubmitted {
+    /// Query ID of the change request.
+    queryId: uint64;
+
+    /// The (merkle leaf) hash of the operation which produced the error.
+    opLeafHash: uint256;
+    /// The hash of the operation execute transaction.
+    opTxHash: uint256;
+
+    /// The hash of the transaction which errored.
+    errorTxHash: uint256;
+    /// The error code.
+    errorCode: uint32;
+
+    /// The current root which was invalidated.
+    root: Cell<uint256>;
+    /// Whether the operation that was pending was the one for which the error was reported.
+    matchesPendingOp: bool;
+}
+
 /// @dev Union of all outgoing messages.
 type MCMS_OutMessage =
     | MCMS_NewRoot
     | MCMS_ConfigSet
-    | MCMS_OpExecuted;
+    | MCMS_OpExecuted
+    | MCMS_ErrorReportSubmitted;
 
 // --- Storage ---
 
@@ -209,7 +256,7 @@ struct MCMS_Data {
     signers: dict; // map<uint256, Signer> - exists if the public key is a signer
 
     /// The current configuration of the contract
-    config: Cell<Config>; // Notice: split out as cell to avoid size limits
+    config: Cell<Config>; // @dev split out as cell to avoid size limits
 
     /// Remember signedHashes that this contract has seen. Each signedHash can only be set once.
     seenSignedHashes: dict; // map<uint256, bool>
@@ -257,82 +304,83 @@ const MAX_NUM_SIGNERS = 200;
 
 const DEFAULT_FINALIZATION_TIMEOUT = 60; // in seconds
 
-/// @notice Thrown when number of signers is 0 or greater than MAX_NUM_SIGNERS.
+/// Thrown when number of signers is 0 or greater than MAX_NUM_SIGNERS.
 const ERROR_OUT_OF_BOUNDS_NUM_SIGNERS = 100;
-/// @notice Thrown when signerKeys and signerGroups have different lengths.
+
+/// Thrown when signerKeys and signerGroups have different lengths.
 const ERROR_SIGNER_GROUPS_LENGTH_MISMATCH = 101;
 
-/// @notice Thrown when number of some signer's group is greater than (NUM_GROUPS-1).
+/// Thrown when number of some signer's group is greater than (NUM_GROUPS-1).
 const ERROR_OUT_OF_BOUNDS_GROUP = 102;
 
-/// @notice Thrown when the group tree isn't well-formed.
+/// Thrown when the group tree isn't well-formed.
 const ERROR_GROUP_TREE_NOT_WELL_FORMED = 103;
 
-/// @notice Thrown when the quorum of some group is larger than the number of signers in it.
+/// Thrown when the quorum of some group is larger than the number of signers in it.
 const ERROR_OUT_OF_BOUNDS_GROUP_QUORUM = 104;
 
-/// @notice Thrown when a disabled group contains a signer.
+/// Thrown when a disabled group contains a signer.
 const ERROR_SIGNER_IN_DISABLED_GROUP = 105;
 
-/// @notice Thrown when the signers' public keys are not a strictly increasing monotone sequence.
+/// Thrown when the signers' public keys are not a strictly increasing monotone sequence.
 /// Prevents signers from including more than one signature.
 const ERROR_SIGNERS_KEYS_MUST_BE_STRICTLY_INCREASING = 106;
 
-/// @notice Thrown when the signature corresponds to invalid signer.
+/// Thrown when the signature corresponds to invalid signer.
 const ERROR_INVALID_SIGNER = 107;
 
-/// @notice Thrown when there is no sufficient set of valid signatures provided to make the
+/// Thrown when there is no sufficient set of valid signatures provided to make the
 /// root group successful.
 const ERROR_INSUFFICIENT_SIGNERS = 108;
 
-/// @notice Thrown when attempt to set metadata or execute op for another chain.
+/// Thrown when attempt to set metadata or execute op for another chain.
 const ERROR_WRONG_CHAIN_ID = 109;
 
-/// @notice Thrown when the multiSig address in metadata or op is
+/// Thrown when the multiSig address in metadata or op is
 /// incompatible with the address of this contract.
 const ERROR_WRONG_MULTI_SIG = 110;
 
-/// @notice Thrown when the preOpCount <= postOpCount invariant is violated.
+/// Thrown when the preOpCount <= postOpCount invariant is violated.
 const ERROR_WRONG_POST_OP_COUNT = 111;
 
-/// @notice Thrown when attempting to set a new root while there are still pending ops
+/// Thrown when attempting to set a new root while there are still pending ops
 /// from the previous root without explicitly overriding it.
 const ERROR_PENDING_OPS = 112;
 
-/// @notice Thrown when preOpCount in metadata is incompatible with the current opCount.
+/// Thrown when preOpCount in metadata is incompatible with the current opCount.
 const ERROR_WRONG_PRE_OP_COUNT = 113;
 
-/// @notice Thrown when the provided merkle proof cannot be verified.
+/// Thrown when the provided merkle proof cannot be verified.
 const ERROR_PROOF_CANNOT_BE_VERIFIED = 114;
 
-/// @notice Thrown when attempt to execute an op after
+/// Thrown when attempt to execute an op after
 /// data.rootInfo.expiringRootAndOpCount.validUntil has passed.
 const ERROR_ROOT_EXPIRED = 115;
 
-/// @notice Thrown when attempt to bypass the enforced ops' order in the merkle tree or
+/// Thrown when attempt to bypass the enforced ops' order in the merkle tree or
 /// re-execute an op.
 const ERROR_WRONG_NONCE = 116;
 
-/// @notice Thrown when attempting to execute an op even though opCount equals
+/// Thrown when attempting to execute an op even though opCount equals
 /// metadata.postOpCount.
 const ERROR_POST_OP_COUNT_REACHED = 117;
 
-/// @notice Thrown when the underlying call in _execute() reverts.
+/// Thrown when the underlying call in _execute() reverts.
 const ERROR_CALL_REVERTED = 118;
 
-/// @notice Thrown when attempt to set past validUntil for the root.
+/// Thrown when attempt to set past validUntil for the root.
 const ERROR_VALID_UNTIL_HAS_ALREADY_PASSED = 119;
 
-/// @notice Thrown when setRoot() is called before setting a config.
+/// Thrown when setRoot() is called before setting a config.
 const ERROR_MISSING_CONFIG = 120;
 
-/// @notice Thrown when attempt to set the same (root, validUntil) in setRoot().
+/// Thrown when attempt to set the same (root, validUntil) in setRoot().
 const ERROR_SIGNED_HASH_ALREADY_SEEN = 121;
 
-/// @notice Thrown when the root has not been finalized yet (can't execute next op before finalization).
+/// Thrown when the root has not been finalized yet (can't execute next op before finalization).
 const ERROR_ROOT_NOT_FINALIZED = 122;
 
-/// @notice Thrown when the provided op.value is insufficient (min required value not met).
+/// Thrown when the provided op.value is insufficient (min required value not met).
 const ERROR_INSUFFICIENT_VALUE = 123;
 
 // --- Constants - storage ---
@@ -439,7 +487,8 @@ struct ExpiringRootAndOpCount {
 }
 
 /// Information about the currently pending operation.
-/// This is TON-specific additional data required to support reliable execution in the async environment.
+///
+/// @dev TON-specific additional data required to support reliable execution in the async environment.
 struct OpPendingInfo {
     /// The time at which the root becomes valid [executionTime(opCount - 1) + opFinalizationTimeout].
     /// At this time the previous executed operation is considered optimistically final and successful,
@@ -451,10 +500,10 @@ struct OpPendingInfo {
     opPendingReceiver: address;
     /// The truncated body of the pending operation (256 bits from the original message),
     /// stored as the next expected potential bounce, and verified in onBounceMessage handler.
-    opPendingBodyVal: uint256;
+    opPendingBodyTruncated: uint256;
 }
 
-/// @notice Each root also authenticates metadata about itself (stored as one of the leaves)
+/// Each root also authenticates metadata about itself (stored as one of the leaves)
 /// which must be revealed when the root is set.
 ///
 /// @dev We need to be careful that abi.encode(MANY_CHAIN_MULTI_SIG_DOMAIN_SEPARATOR_METADATA, RootMetadata)
@@ -482,7 +531,7 @@ struct RootMetadata {
 
 /// @dev An ECDSA signature.
 struct Signature {
-    // Notice: no `v: uint8;` field, as public key recovery is not supported.
+    // @dev no `v: uint8;` field, as public key recovery is not supported.
     r: uint256;
     s: uint256;
 
@@ -490,7 +539,7 @@ struct Signature {
     signer: uint256;
 }
 
-/// @notice an op to be executed by the ManyChainMultiSig contract
+/// An op to be executed by the ManyChainMultiSig contract
 ///
 /// @dev We need to be careful that abi.encode(LEAF_OP_DOMAIN_SEPARATOR, RootMetadata)
 /// is greater than 64 bytes to prevent collisions with internal nodes in the Merkle tree. See
@@ -519,7 +568,7 @@ fun MCMS<T>.load(context: T? = null, hooks: MCMS_Hooks<T>? = null): MCMS<T> {
     };
 }
 
-/// @notice setRoot Sets a new expiring root.
+/// setRoot Sets a new expiring root.
 ///
 /// @param root is the new expiring root.
 /// @param validUntil is the time by which root is valid
@@ -611,7 +660,7 @@ fun MCMS<T>.setRoot(
                 throw ERROR_INVALID_SIGNER;
             }
 
-            // Notice: break/continue from loops are not supported yet in Tolk.
+            // @dev break/continue from loops are not supported yet in Tolk.
             // Instead, we use a flag to indicate whether we should break the loop.
             var _break = false;
             var group = signer.group;
@@ -672,7 +721,7 @@ fun MCMS<T>.setRoot(
 
     {
         // verify metadataProof
-        // Notice: we use the standard sha256 hash function to hash the leaf.
+        // @dev we use the standard sha256 hash function to hash the leaf.
         val hashedLeaf =
             beginCell()
                 .storeUint(MANY_CHAIN_MULTI_SIG_DOMAIN_SEPARATOR_METADATA, 256)
@@ -726,22 +775,23 @@ fun MCMS<T>.setRoot(
                 validAfter: blockchain.now(), // immediate
                 opFinalizationTimeout,
                 opPendingReceiver: createAddressNone(),
-                opPendingBodyVal: 0,
+                opPendingBodyTruncated: 0,
             }.toCell()
         },
         rootMetadata: metadata,
     }.toCell();
 
     // Reply to sender new root was set, return excess
-    createMessage({
+    val reply = createMessage({
         bounce: false,
         value: 0,
         dest: sender,
         body: MCMS_NewRoot{queryId, root, validUntil, metadata}
-    }).send(SEND_MODE_REGULAR | SEND_MODE_CARRY_ALL_REMAINING_MESSAGE_VALUE);
+    });
+    reply.send(SEND_MODE_REGULAR | SEND_MODE_CARRY_ALL_REMAINING_MESSAGE_VALUE);
 }
 
-/// @notice Execute the received op after verifying the proof of its inclusion in the
+/// Execute the received op after verifying the proof of its inclusion in the
 /// current Merkle tree. The op should be the next op according to the order
 /// enforced by the merkle tree whose root is stored in data.rootInfo.expiringRootAndOpCount, i.e., the
 /// nonce of the op should be equal to data.rootInfo.expiringRootAndOpCount.opCount.
@@ -805,7 +855,7 @@ fun MCMS<T>.execute(
     }
 
     // verify that the op exists in the merkle tree
-    // Notice: we use the standard sha256 hash function to hash the leaf.
+    // @dev we use the standard sha256 hash function to hash the leaf.
     val hashedLeaf =
         beginCell()
             .storeUint(MANY_CHAIN_MULTI_SIG_DOMAIN_SEPARATOR_OP, 256)
@@ -826,7 +876,7 @@ fun MCMS<T>.execute(
             opCount: currentExpiringRootAndOpCount.opCount + 1,
             // TON-specific additions below to support the async environment
             opPendingInfo: OpPendingInfo{
-                // Notice: we set optimistic finalization of an async operation using a timeout
+                // @dev we set optimistic finalization of an async operation using a timeout
                 // Within that timeout executions are paused as we wait for the finalization signal
                 //
                 // To finalize an execution, one of two conditions must be met:
@@ -837,7 +887,7 @@ fun MCMS<T>.execute(
                 opFinalizationTimeout: opPendingInfo.opFinalizationTimeout,
                 // Store the pending message info (checked onBouncedMessage)
                 opPendingReceiver: op.to,
-                opPendingBodyVal: extractBouncedBody(op.data.beginParse())
+                opPendingBodyTruncated: extractBouncedBody(op.data.beginParse())
             }.toCell()
         },
         rootMetadata
@@ -846,15 +896,16 @@ fun MCMS<T>.execute(
     self._execute(op.to, op.value, op.data);
 
     // Reply back to sender
-    createMessage({
+    val reply = createMessage({
         bounce: false,
         value: minValue, // send small value as gas budget, keep the rest
         dest: sender,
         body: MCMS_OpExecuted{queryId, nonce: op.nonce, to: op.to, data: op.data, value: op.value}
-    }).send(SEND_MODE_REGULAR);
+    });
+    reply.send(SEND_MODE_REGULAR);
 }
 
-/// @notice sets a new data.config. If clearRoot is true, then it also invalidates
+/// setConfig sets a new data.config. If clearRoot is true, then it also invalidates
 /// data.rootInfo.expiringRootAndOpCount.root.
 ///
 /// @param signerKeys holds the public keys of the active signers. The keys must be in
@@ -1043,7 +1094,7 @@ fun MCMS<T>.setConfig(
                     validAfter: blockchain.now(), // immediate
                     opFinalizationTimeout: 0,
                     opPendingReceiver: createAddressNone(),
-                    opPendingBodyVal: 0
+                    opPendingBodyTruncated: 0
                 }.toCell()
             },
             rootMetadata: RootMetadata{
@@ -1057,7 +1108,7 @@ fun MCMS<T>.setConfig(
     }
 
     // Reply to sender config is set, return excess
-    createMessage({
+    val reply = createMessage({
         bounce: false,
         value: 0,
         dest: sender,
@@ -1066,10 +1117,86 @@ fun MCMS<T>.setConfig(
             config: Config.fromCell(self.data.config),
             isRootCleared: clearRoot
         }
-    }).send(SEND_MODE_REGULAR | SEND_MODE_CARRY_ALL_REMAINING_MESSAGE_VALUE);
+    });
+    reply.send(SEND_MODE_REGULAR | SEND_MODE_CARRY_ALL_REMAINING_MESSAGE_VALUE);
 }
 
-/// @notice Execute an op's call. Performs a raw message send that can bounce on errors.
+/// Submit an oracle error report, which marks the current root as invalid.
+///
+/// @see <MCMS_SubmitErrorReport> for more information.
+fun MCMS<T>.submitErrorReport(
+    mutate self,
+    sender: address,
+    queryId: uint64,
+    op: Op,
+    proof: Iterator<uint256>,
+    opTxHash: uint256,
+    errorTxHash: uint256,
+    errorCode: uint32
+) {
+    // TODO: check oracle access
+
+    var rootInfo = lazy RootInfo.fromCell(self.data.rootInfo);
+
+    // Check if right environment via chainId
+    if (op.chainId != globalId() as int256) {
+        throw ERROR_WRONG_CHAIN_ID;
+    }
+
+    if (op.multiSig != contract.getAddress()) {
+        throw ERROR_WRONG_MULTI_SIG;
+    }
+
+    if (blockchain.now() > rootInfo.expiringRootAndOpCount.validUntil) {
+        throw ERROR_ROOT_EXPIRED;
+    }
+
+    // verify that the op exists in the merkle tree
+    // @dev we use the standard sha256 hash function to hash the leaf.
+    val hashedLeaf =
+        beginCell()
+            .storeUint(MANY_CHAIN_MULTI_SIG_DOMAIN_SEPARATOR_OP, 256)
+            .storeRef(op.toCell())
+            .endCell()
+            .hash();
+    // "../lib/crypto/merkle_proof.tolk"
+    if (!verify(proof, rootInfo.expiringRootAndOpCount.root, hashedLeaf)) {
+        throw ERROR_PROOF_CANNOT_BE_VERIFIED;
+    }
+
+    // Mark root in error state (recover with new root + bypass)
+    rootInfo.expiringRootAndOpCount.validUntil = blockchain.now(); // expire root immediately
+    self.data.rootInfo = rootInfo.toCell();
+
+    // Check the reported error against the stored pending operation
+    val opPendingInfo = lazy OpPendingInfo.fromCell(rootInfo.expiringRootAndOpCount.opPendingInfo);
+
+    val matchesPendingOp = opPendingInfo.opPendingReceiver == op.to
+        && opPendingInfo.opPendingBodyTruncated == extractBouncedBody(op.data.beginParse());
+
+    // Store the root in a separate cell (size limit)
+    val root = beginCell()
+        .storeUint(rootInfo.expiringRootAndOpCount.root, 256)
+        .endCell() as Cell<uint256>;
+
+    val reply = createMessage({
+        bounce: false,
+        value: 0,
+        dest: sender,
+        body: MCMS_ErrorReportSubmitted{
+            queryId,
+            opLeafHash: hashedLeaf,
+            opTxHash,
+            errorTxHash,
+            errorCode,
+            root,
+            matchesPendingOp,
+        }
+    });
+    reply.send(SEND_MODE_REGULAR | SEND_MODE_CARRY_ALL_REMAINING_MESSAGE_VALUE);
+}
+
+/// Execute an op's call. Performs a raw message send that can bounce on errors.
 fun MCMS<T>._execute(self, target: address, value: coins, data: cell): void {
     if (self.hooks != null && self.hooks.execute != null) {
         return self.hooks.execute(self.context, target, value, data); // extension hook
@@ -1081,7 +1208,7 @@ fun MCMS<T>._execute(self, target: address, value: coins, data: cell): void {
         value: value,
         dest: target,
         body: data
-    }).send(SEND_MODE_PAY_FEES_SEPARATELY);
+    }).send(SEND_MODE_PAY_FEES_SEPARATELY | SEND_MODE_BOUNCE_ON_ACTION_FAIL);
 }
 
 /// Returns the current configuration of the contract
@@ -1119,8 +1246,7 @@ fun MCMS<T>.onInternalMessage(mutate self, msgSender: address, msgValue: coins, 
     val msg = lazy MCMS_InMessage.fromSlice(msgBody);
     match (msg) {
         MCMS_TopUp => {
-            // Top up the contract balance, no action needed, return early - no need to update storage
-            return;
+            // Top up the contract balance, no action needed
         }
         MCMS_SetRoot => {
             self.setRoot(msgSender, msg.queryId, msg.root, msg.validUntil, msg.metadata,
@@ -1134,15 +1260,18 @@ fun MCMS<T>.onInternalMessage(mutate self, msgSender: address, msgValue: coins, 
             self.setConfig(msgSender, msg.queryId, msg.signerKeys, msg.signerGroups,
                 msg.groupQuorums, msg.groupParents, msg.clearRoot);
         }
-        // TODO: implement oracle error report handling for a category of errors which might occur during execution
-        // of an operation, but can't be caught on-chain (OOG errors, and downstream tx-trace errors).
+        MCMS_SubmitErrorReport => {
+            self.submitErrorReport(msgSender, msg.queryId, Op.fromCell(msg.op),
+                Iterator<uint256>.new(msg.proof), msg.opTxHash, msg.errorTxHash, msg.errorCode);
+        }
         else => {
             val msgHandled = 0
                 || self.data.ownable.onInternalMessage(msgSender, msgBody);
 
             if (!msgHandled) {
-                // If the message was not handled, throw an error
-                throw ERROR_WRONG_OP;
+                // If the message was not handled
+                // ignore empty messages, "wrong opcode" for others
+                assert (msgBody.isEmpty()) throw ERROR_WRONG_OP;
             }
         }
     }
@@ -1158,10 +1287,10 @@ fun onBouncedMessage(in: InMessageBounced) {
     // Check the bounced message against the stored pending operation
     // If the received bounce does NOT equal expected, mark the root invalid.
     //
-    // Notice: on setRoot the OpPendingInfo is cleared, so a bounce from an old root will not match
-    val bouncedBodyVal = extractBouncedBody(in.bouncedBody.skipBouncedPrefix());
+    // @dev on setRoot the OpPendingInfo is cleared, so a bounce from an old root will not match
+    val bouncedBody = extractBouncedBody(in.bouncedBody.skipBouncedPrefix());
     if (opPendingInfo.opPendingReceiver != in.senderAddress
-        || opPendingInfo.opPendingBodyVal != bouncedBodyVal) {
+        || opPendingInfo.opPendingBodyTruncated != bouncedBody) {
         // Mark root in error state (recover with new root + bypass)
         rootInfo.expiringRootAndOpCount.validUntil = blockchain.now(); // expire root immediately
         mcms.data.rootInfo = rootInfo.toCell();
@@ -1173,7 +1302,7 @@ fun onBouncedMessage(in: InMessageBounced) {
     rootInfo.expiringRootAndOpCount.opCount = rootInfo.expiringRootAndOpCount.opCount - 1;
     opPendingInfo.validAfter = blockchain.now(); // can be retried immediately
     opPendingInfo.opPendingReceiver = createAddressNone();
-    opPendingInfo.opPendingBodyVal = 0;
+    opPendingInfo.opPendingBodyTruncated = 0;
 
     rootInfo.expiringRootAndOpCount.opPendingInfo = opPendingInfo.toCell();
     mcms.data.rootInfo = rootInfo.toCell();

--- a/contracts/contracts/mcms/mcms.tolk
+++ b/contracts/contracts/mcms/mcms.tolk
@@ -6,7 +6,6 @@ import "@stdlib/gas-payments";
 import "../lib/utils";
 import "../lib/access/ownable_2step.tolk";
 import "../lib/crypto/merkle_proof.tolk";
-import "../lib/ocr/exit_codes"
 
 /// This is a multi-sig contract that supports signing many transactions (called "ops" in
 /// the context of this contract to prevent confusion with transactions on the underlying chain)
@@ -156,13 +155,25 @@ struct (0x43ebc734) MCMS_SubmitErrorReport {
     errorCode: uint32;
 }
 
+/// Message sent by the owner to transfer the oracle role.
+struct (0xf275742f) MCMS_TransferOracleRole {
+    /// Query ID of the change request.
+    queryId: uint64;
+    /// The address of the new oracle.
+    newOracle: address;
+}
+
 /// @dev Union of all incoming messages.
 type MCMS_InMessage =
     | MCMS_TopUp
     | MCMS_SetRoot
     | MCMS_Execute
     | MCMS_SetConfig
-    | MCMS_SubmitErrorReport;
+    | MCMS_SubmitErrorReport
+    | MCMS_TransferOracleRole
+    // when mcms owns itself
+    | MCMS_ConfigSet
+    | MCMS_OracleRoleTransferred;
 
 // --- Messages - outgoing ---
 
@@ -226,12 +237,23 @@ struct (0x43ebc734) MCMS_ErrorReportSubmitted {
     matchesPendingOp: bool;
 }
 
+/// Event emitted by the contract when the oracle role is transferred.
+struct (0xff4176a3) MCMS_OracleRoleTransferred {
+    /// Query ID of the change request.
+    queryId: uint64;
+    /// The address of the old oracle.
+    oldOracle: address;
+    /// The address of the new oracle.
+    newOracle: address;
+}
+
 /// @dev Union of all outgoing messages.
 type MCMS_OutMessage =
     | MCMS_NewRoot
     | MCMS_ConfigSet
     | MCMS_OpExecuted
-    | MCMS_ErrorReportSubmitted;
+    | MCMS_ErrorReportSubmitted
+    | MCMS_OracleRoleTransferred;
 
 // --- Storage ---
 
@@ -1206,6 +1228,29 @@ fun MCMS<T>.submitErrorReport(
     reply.send(SEND_MODE_REGULAR | SEND_MODE_CARRY_ALL_REMAINING_MESSAGE_VALUE);
 }
 
+/// Transfer the error oracle role - requires owner.
+///
+/// @see <MCMS_TransferOracleRole> for more information.
+fun MCMS<T>.transferOracleRole(
+    mutate self,
+    sender: address,
+    queryId: uint64,
+    newOracle: address
+) {
+    self.data.ownable.requireOwner(sender);
+
+    val oldOracle = self.data.oracle;
+    self.data.oracle = newOracle;
+
+    val reply = createMessage({
+        bounce: false,
+        value: 0,
+        dest: sender,
+        body: MCMS_OracleRoleTransferred{ queryId, oldOracle, newOracle }
+    });
+    reply.send(SEND_MODE_REGULAR | SEND_MODE_CARRY_ALL_REMAINING_MESSAGE_VALUE);
+}
+
 /// Execute an op's call. Performs a raw message send that can bounce on errors.
 fun MCMS<T>._execute(self, target: address, value: coins, data: cell): void {
     if (self.hooks != null && self.hooks.execute != null) {
@@ -1213,12 +1258,13 @@ fun MCMS<T>._execute(self, target: address, value: coins, data: cell): void {
     }
 
     // Send a message to the target with the provided value and data
-    createMessage({
+    val op = createMessage({
         bounce: true,
         value: value,
         dest: target,
         body: data
-    }).send(SEND_MODE_PAY_FEES_SEPARATELY | SEND_MODE_BOUNCE_ON_ACTION_FAIL);
+    });
+    op.send(SEND_MODE_PAY_FEES_SEPARATELY | SEND_MODE_BOUNCE_ON_ACTION_FAIL);
 }
 
 /// Returns the current configuration of the contract
@@ -1238,7 +1284,7 @@ fun MCMS<T>.getRoot(self): (uint256, uint32) {
     return (rootInfo.expiringRootAndOpCount.root, rootInfo.expiringRootAndOpCount.validUntil);
 }
 
-// Returns the current pending operation information.
+/// Returns the current pending operation information.
 fun MCMS<T>.getOpPendingInfo(self): OpPendingInfo {
     val rootInfo = lazy RootInfo.fromCell(self.data.rootInfo);
     return OpPendingInfo.fromCell(rootInfo.expiringRootAndOpCount.opPendingInfo);
@@ -1247,6 +1293,11 @@ fun MCMS<T>.getOpPendingInfo(self): OpPendingInfo {
 /// Returns the current metadata about the root, which is stored as one of the leaves.
 fun MCMS<T>.getRootMetadata(self): RootMetadata {
     return RootInfo.fromCell(self.data.rootInfo).rootMetadata;
+}
+
+/// Returns the current oracle account, which can submit error reports.
+fun MCMS<T>.getOracle(self): address {
+    return self.data.oracle;
 }
 
 // --- Message handlers ---
@@ -1274,7 +1325,15 @@ fun MCMS<T>.onInternalMessage(mutate self, msgSender: address, msgValue: coins, 
             self.submitErrorReport(msgSender, msg.queryId, Op.fromCell(msg.op),
                 Iterator<uint256>.new(msg.proof), msg.opTxHash, msg.errorTxHash, msg.errorCode);
         }
-        // TODO: only owner should be able to update the error oracle
+        MCMS_TransferOracleRole => {
+            self.transferOracleRole(msgSender, msg.queryId, msg.newOracle);
+        }
+        MCMS_OracleRoleTransferred => {
+            // noop
+        }
+        MCMS_ConfigSet => {
+            // noop
+        }
         else => {
             val msgHandled = 0
                 || self.data.ownable.onInternalMessage(msgSender, msgBody);
@@ -1358,6 +1417,11 @@ get fun getOpPendingInfo(): OpPendingInfo {
 /// @see <MCMS<T>.getRootMetadata>
 get fun getRootMetadata(): RootMetadata {
     return MCMS<bool>.load().getRootMetadata();
+}
+
+/// @see <MCMS<T>.getOracle>
+get fun getOracle(): address {
+    return MCMS<bool>.load().getOracle();
 }
 
 // --- Getters - Ownable2Step ---

--- a/contracts/contracts/mcms/mcms.tolk
+++ b/contracts/contracts/mcms/mcms.tolk
@@ -792,10 +792,6 @@ fun MCMS<T>.execute(
         throw ERROR_ROOT_NOT_FINALIZED;
     }
 
-    debug.printString("NONCE");
-    debug.print(op.nonce);
-    debug.print(currentExpiringRootAndOpCount.opCount);
-
     if (op.nonce != currentExpiringRootAndOpCount.opCount) {
         throw ERROR_WRONG_NONCE;
     }
@@ -1138,6 +1134,8 @@ fun MCMS<T>.onInternalMessage(mutate self, msgSender: address, msgValue: coins, 
             self.setConfig(msgSender, msg.queryId, msg.signerKeys, msg.signerGroups,
                 msg.groupQuorums, msg.groupParents, msg.clearRoot);
         }
+        // TODO: implement oracle error report handling for a category of errors which might occur during execution
+        // of an operation, but can't be caught on-chain (OOG errors, and downstream tx-trace errors).
         else => {
             val msgHandled = 0
                 || self.data.ownable.onInternalMessage(msgSender, msgBody);
@@ -1157,23 +1155,10 @@ fun onBouncedMessage(in: InMessageBounced) {
     var rootInfo = lazy RootInfo.fromCell(mcms.data.rootInfo);
     var opPendingInfo = lazy OpPendingInfo.fromCell(rootInfo.expiringRootAndOpCount.opPendingInfo);
 
-    // If the op was already finalized, we need to drop the bounce, and mark the root invalid.
-    //
-    // This is because subsequent operations might already be executed, and we're not at the
-    // right index in the op sequence to be able to retry the (current) op.
-    //
-    // This is why critical operation sequences need to be commited with a timeout
-    // which will allow enough time for them to be bounced and subsequently retried.
-    if (opPendingInfo.validAfter < blockchain.now()) {
-        // TODO: maybe we can also store and check opCount to see if subsequent ops were executed in the meantime
-        rootInfo.expiringRootAndOpCount.validUntil = blockchain.now(); // expire root immediately
-        mcms.data.rootInfo = rootInfo.toCell();
-        mcms.data.storeAsContractData();
-        return;
-    }
-
     // Check the bounced message against the stored pending operation
     // If the received bounce does NOT equal expected, mark the root invalid.
+    //
+    // Notice: on setRoot the OpPendingInfo is cleared, so a bounce from an old root will not match
     val bouncedBodyVal = extractBouncedBody(in.bouncedBody.skipBouncedPrefix());
     if (opPendingInfo.opPendingReceiver != in.senderAddress
         || opPendingInfo.opPendingBodyVal != bouncedBodyVal) {
@@ -1183,15 +1168,6 @@ fun onBouncedMessage(in: InMessageBounced) {
         mcms.data.storeAsContractData();
         return;
     }
-
-    // TODO!
-    //
-    // Check for edge case where the root is updated before an execution from
-    // a previous root bounced back. We drop late bounces if we have a fresh root.
-    // val rootMetadata = lazy RootMetadata.fromCell(mcms.data.rootMetadata);
-    // if (rootMetadata.preOpCount == mcms.data.expiringRootAndOpCount.opCount) {
-    //     return;
-    // }
 
     // If the received bounce equals expected, revert state (allow op retry)
     rootInfo.expiringRootAndOpCount.opCount = rootInfo.expiringRootAndOpCount.opCount - 1;

--- a/contracts/contracts/mcms/mcms.tolk
+++ b/contracts/contracts/mcms/mcms.tolk
@@ -438,7 +438,7 @@ struct ExpiringRootAndOpCount {
 /// This is TON-specific additional data required to support reliable execution in the async environment.
 struct OpPendingInfo {
     /// The time at which the root becomes valid [executionTime(opCount - 1) + opFinalizationTimeout].
-    /// At this time the previous executed operation is considered optimistically final and succesfull,
+    /// At this time the previous executed operation is considered optimistically final and successful,
     /// meaning no bounce was received and we can continue executing.
     validAfter: uint32;
     /// The timeout required to finalize the currently executing op

--- a/contracts/contracts/mcms/mcms.tolk
+++ b/contracts/contracts/mcms/mcms.tolk
@@ -835,6 +835,8 @@ fun MCMS<T>.execute(
         rootMetadata
     }.toCell();
 
+    // TODO: should we enforce a minimum amount of TON op.value here,
+    // so the receiver at least has enough for gas fee validation + a bounce?
     self._execute(op.to, op.value, op.data);
 
     // Reply back to sender
@@ -1069,7 +1071,7 @@ fun MCMS<T>._execute(self, target: address, value: coins, data: cell): void {
 
     // Send a message to the target with the provided value and data
     createMessage({
-        bounce: true, // TODO: how to handle bounced messages (errors)?
+        bounce: true,
         value: value,
         dest: target,
         body: data
@@ -1115,7 +1117,6 @@ fun MCMS<T>.onInternalMessage(mutate self, msgSender: address, msgValue: coins, 
             return;
         }
         MCMS_SetRoot => {
-            // TODO: make opFinalizationTimeout configurable
             self.setRoot(msgSender, msg.queryId, msg.root, msg.validUntil, msg.metadata,
                 Iterator<uint256>.new(msg.metadataProof), msg.signatures, msg.opFinalizationTimeout);
         }
@@ -1145,9 +1146,6 @@ fun onBouncedMessage(in: InMessageBounced) {
 
     var rootInfo = lazy RootInfo.fromCell(mcms.data.rootInfo);
     var opPendingInfo = lazy OpPendingInfo.fromCell(rootInfo.expiringRootAndOpCount.opPendingInfo);
-
-    debug.printString("BOUNCE");
-    debug.print(in.bouncedBody);
 
     // If the op was already finalized, we need to drop the bounce, and mark the root invalid.
     //

--- a/contracts/contracts/mcms/mcms.tolk
+++ b/contracts/contracts/mcms/mcms.tolk
@@ -71,16 +71,18 @@ struct (0xe7fabde3) MCMS_SetRoot {
     metadataProof: cell; // vec<uint256>;
     /// The ECDSA signatures on (root, validUntil).
     signatures: cell; // vec<Signature>
+    /// The timeout required to finalize the currently executing op
+    opFinalizationTimeout: uint32;
 }
 
 /// @notice Execute the received op after verifying the proof of its inclusion in the
 /// current Merkle tree. The op should be the next op according to the order
-/// enforced by the merkle tree whose root is stored in data.expiringRootAndOpCount, i.e., the
-/// nonce of the op should be equal to data.expiringRootAndOpCount.opCount.
+/// enforced by the merkle tree whose root is stored in data.rootInfo.expiringRootAndOpCount, i.e., the
+/// nonce of the op should be equal to data.rootInfo.expiringRootAndOpCount.opCount.
 ///
 /// @param op is Op to be executed
 /// @param proof is the MerkleProof for the op's inclusion in the MerkleTree which its
-/// root is the data.expiringRootAndOpCount.root.
+/// root is the data.rootInfo.expiringRootAndOpCount.root.
 ///
 /// @dev ANYONE can call this function! That's intentional. Callers can only execute verified,
 /// ordered ops in the Merkle tree.
@@ -101,7 +103,7 @@ struct (0x9b9ce96a) MCMS_Execute {
 }
 
 /// @notice sets a new data.config. If clearRoot is true, then it also invalidates
-/// data.expiringRootAndOpCount.root.
+/// data.rootInfo.expiringRootAndOpCount.root.
 ///
 /// @param signerKeys holds the public keys of the active signers. The keys must be in
 /// ascending order.
@@ -129,7 +131,8 @@ struct (0x89277f4b) MCMS_SetConfig {
 }
 
 /// @dev Union of all incoming messages.
-type MCMS_InMessage = MCMS_TopUp
+type MCMS_InMessage =
+    | MCMS_TopUp
     | MCMS_SetRoot
     | MCMS_Execute
     | MCMS_SetConfig;
@@ -176,7 +179,8 @@ struct (0x7cf37cbf) MCMS_OpExecuted {
 }
 
 /// @dev Union of all outgoing messages.
-type MCMS_OutMessage = MCMS_NewRoot
+type MCMS_OutMessage =
+    | MCMS_NewRoot
     | MCMS_ConfigSet
     | MCMS_OpExecuted;
 
@@ -208,10 +212,9 @@ struct MCMS_Data {
 
     /// Remember signedHashes that this contract has seen. Each signedHash can only be set once.
     seenSignedHashes: dict; // map<uint256, bool>
-    /// The current expiring root and the number of ops in it.
-    expiringRootAndOpCount: ExpiringRootAndOpCount; // TODO: Error: contracts/mcms/mcms.tolk:195: error: struct `MCMS_Data` can exceed 1023 bits in serialization (estimated size: 687..1484 bits)
-    /// The current metadata about the root.
-    rootMetadata: Cell<RootMetadata>; // Notice: split out as cell to avoid size limits
+
+    /// The current RootMetadata and ExpiringRootAndOpCount wrapped in a cell bc size limits.
+    rootInfo: Cell<RootInfo>;
 }
 
 /// Load from contract data using auto-serialization.
@@ -302,7 +305,7 @@ const ERROR_WRONG_PRE_OP_COUNT = 113;
 const ERROR_PROOF_CANNOT_BE_VERIFIED = 114;
 
 /// @notice Thrown when attempt to execute an op after
-/// data.expiringRootAndOpCount.validUntil has passed.
+/// data.rootInfo.expiringRootAndOpCount.validUntil has passed.
 const ERROR_ROOT_EXPIRED = 115;
 
 /// @notice Thrown when attempt to bypass the enforced ops' order in the merkle tree or
@@ -403,6 +406,14 @@ struct Config {
     groupParents: dict; // map<uint8, uint8> (indexed, iterable backwards)
 }
 
+/// Information about the current root, extracted into a separate struct (wrapped in a cell).
+struct RootInfo {
+    /// The current expiring root and the number of ops in it.
+    expiringRootAndOpCount: ExpiringRootAndOpCount;
+    /// The current metadata about the root.
+    rootMetadata: RootMetadata;
+}
+
 /// MerkleRoots are a bit tricky since they reveal almost no information about the contents of
 /// the tree they authenticate. To mitigate this, we enforce that this contract can only execute
 /// ops from a single root at any given point in time. We further associate an expiry
@@ -419,9 +430,13 @@ struct ExpiringRootAndOpCount {
     validUntil: uint32;
     /// each ManyChainMultiSig instance has it own independent opCount.
     opCount: uint40;
+    /// Information about the currently pending operation.
+    opPendingInfo: Cell<OpPendingInfo>
+}
 
-    /// TON-specific additions below to support the async environment
-    ///
+/// Information about the currently pending operation.
+/// This is TON-specific additional data required to support reliable execution in the async environment.
+struct OpPendingInfo {
     /// The time at which the root becomes valid [executionTime(opCount - 1) + opFinalizationTimeout].
     /// At this time the previous executed operation is considered optimistically final and succesfull,
     /// meaning no bounce was received and we can continue executing.
@@ -464,7 +479,6 @@ struct RootMetadata {
 /// @dev An ECDSA signature.
 struct Signature {
     // Notice: no `v: uint8;` field, as public key recovery is not supported.
-
     r: uint256;
     s: uint256;
 
@@ -676,14 +690,13 @@ fun MCMS<T>.setRoot(
         throw ERROR_WRONG_MULTI_SIG;
     }
 
-    val opCount: uint40 = self.data.expiringRootAndOpCount.opCount;
+    // Unpack the root info from the contract data
+    val rootInfo = lazy RootInfo.fromCell(self.data.rootInfo);
 
     // don't allow a new root to be set if there are still outstanding ops that have not been
     // executed, unless overridePreviousRoot is set
-    //
-    // Unpack the root metadata from the contract data
-    val rootMetadata = lazy RootMetadata.fromCell(self.data.rootMetadata);
-    if (opCount != rootMetadata.postOpCount && !metadata.overridePreviousRoot) {
+    val opCount: uint40 = rootInfo.expiringRootAndOpCount.opCount;
+    if (opCount != rootInfo.rootMetadata.postOpCount && !metadata.overridePreviousRoot) {
         throw ERROR_PENDING_OPS;
     }
 
@@ -699,17 +712,21 @@ fun MCMS<T>.setRoot(
 
     // done with validation, persist in in contract state
     self.data.seenSignedHashes.uDictSet(256, signedHash, createEmptySlice());
-    self.data.expiringRootAndOpCount = ExpiringRootAndOpCount{
-        root,
-        validUntil,
-        opCount: metadata.preOpCount,
-        // TON-specific additions below to support the async environment
-        validAfter: blockchain.now(), // immediate
-        opFinalizationTimeout,
-        opPendingReceiver: createAddressNone(),
-        opPendingBodyVal: 0,
-    };
-    self.data.rootMetadata = metadata.toCell();
+    self.data.rootInfo = RootInfo {
+        expiringRootAndOpCount: ExpiringRootAndOpCount{
+            root,
+            validUntil,
+            opCount: metadata.preOpCount,
+            // TON-specific additions below to support the async environment
+            opPendingInfo: OpPendingInfo{
+                validAfter: blockchain.now(), // immediate
+                opFinalizationTimeout,
+                opPendingReceiver: createAddressNone(),
+                opPendingBodyVal: 0,
+            }.toCell()
+        },
+        rootMetadata: metadata,
+    }.toCell();
 
     // Reply to sender new root was set, return excess
     createMessage({
@@ -722,12 +739,12 @@ fun MCMS<T>.setRoot(
 
 /// @notice Execute the received op after verifying the proof of its inclusion in the
 /// current Merkle tree. The op should be the next op according to the order
-/// enforced by the merkle tree whose root is stored in data.expiringRootAndOpCount, i.e., the
-/// nonce of the op should be equal to data.expiringRootAndOpCount.opCount.
+/// enforced by the merkle tree whose root is stored in data.rootInfo.expiringRootAndOpCount, i.e., the
+/// nonce of the op should be equal to data.rootInfo.expiringRootAndOpCount.opCount.
 ///
 /// @param op is Op to be executed
 /// @param proof is the MerkleProof for the op's inclusion in the MerkleTree which its
-/// root is the data.expiringRootAndOpCount.root.
+/// root is the data.rootInfo.expiringRootAndOpCount.root.
 ///
 /// @dev ANYONE can call this function! That's intentional. Callers can only execute verified,
 /// ordered ops in the Merkle tree.
@@ -744,10 +761,10 @@ fun MCMS<T>.execute(
     op: Op,
     proof: Iterator<uint256>,
 ) {
-    val currentExpiringRootAndOpCount = self.data.expiringRootAndOpCount;
-
-    // Unpack the root metadata from the contract data
-    val rootMetadata = lazy RootMetadata.fromCell(self.data.rootMetadata);
+    // Unpack the root info from the contract data
+    val rootInfo = lazy RootInfo.fromCell(self.data.rootInfo);
+    val currentExpiringRootAndOpCount = rootInfo.expiringRootAndOpCount;
+    val rootMetadata = rootInfo.rootMetadata;
 
     if (rootMetadata.postOpCount <= currentExpiringRootAndOpCount.opCount) {
         throw ERROR_POST_OP_COUNT_REACHED;
@@ -766,9 +783,14 @@ fun MCMS<T>.execute(
         throw ERROR_ROOT_EXPIRED;
     }
 
-    if (blockchain.now() < currentExpiringRootAndOpCount.validAfter) {
+    val opPendingInfo = lazy OpPendingInfo.fromCell(currentExpiringRootAndOpCount.opPendingInfo);
+    if (blockchain.now() < opPendingInfo.validAfter) {
         throw ERROR_ROOT_NOT_FINALIZED;
     }
+
+    debug.printString("NONCE");
+    debug.print(op.nonce);
+    debug.print(currentExpiringRootAndOpCount.opCount);
 
     if (op.nonce != currentExpiringRootAndOpCount.opCount) {
         throw ERROR_WRONG_NONCE;
@@ -787,21 +809,31 @@ fun MCMS<T>.execute(
         throw ERROR_PROOF_CANNOT_BE_VERIFIED;
     }
 
-    // increase the counter *before* execution to prevent reentrancy issues
-    self.data.expiringRootAndOpCount.opCount = currentExpiringRootAndOpCount.opCount + 1;
-
-    // Notice: we set optimistic finalization of an async operation using a timeout
-    // Within that timeout executions are paused as we wait for the finalization signal
-    //
-    // To finalize an execution, one of two conditions must be met:
-    // 1. Finalization timeout expired (can continue)
-    // 2. Message bounced back         (can retry)
-    self.data.expiringRootAndOpCount.validAfter =
-        blockchain.now() + self.data.expiringRootAndOpCount.opFinalizationTimeout;
-
-    // Store the pending message info (checked onBouncedMessage)
-    self.data.expiringRootAndOpCount.opPendingReceiver = op.to;
-    self.data.expiringRootAndOpCount.opPendingBodyVal = extractBouncedBody(op.data.beginParse());
+    // Update the state
+    self.data.rootInfo = RootInfo{
+        expiringRootAndOpCount: {
+            root: currentExpiringRootAndOpCount.root,
+            validUntil: currentExpiringRootAndOpCount.validUntil,
+            // increase the counter *before* execution to prevent reentrancy issues
+            opCount: currentExpiringRootAndOpCount.opCount + 1,
+            // TON-specific additions below to support the async environment
+            opPendingInfo: OpPendingInfo{
+                // Notice: we set optimistic finalization of an async operation using a timeout
+                // Within that timeout executions are paused as we wait for the finalization signal
+                //
+                // To finalize an execution, one of two conditions must be met:
+                // 1. Finalization timeout expired                      [can continue]
+                // 2. Message bounced back                              [can retry]
+                // 3. Oracle reported an error (e.g., out-of-gas error) [root invalidated, can't retry]
+                validAfter: blockchain.now() + opPendingInfo.opFinalizationTimeout,
+                opFinalizationTimeout: opPendingInfo.opFinalizationTimeout,
+                // Store the pending message info (checked onBouncedMessage)
+                opPendingReceiver: op.to,
+                opPendingBodyVal: extractBouncedBody(op.data.beginParse())
+            }.toCell()
+        },
+        rootMetadata
+    }.toCell();
 
     self._execute(op.to, op.value, op.data);
 
@@ -815,7 +847,7 @@ fun MCMS<T>.execute(
 }
 
 /// @notice sets a new data.config. If clearRoot is true, then it also invalidates
-/// data.expiringRootAndOpCount.root.
+/// data.rootInfo.expiringRootAndOpCount.root.
 ///
 /// @param signerKeys holds the public keys of the active signers. The keys must be in
 /// ascending order.
@@ -991,23 +1023,28 @@ fun MCMS<T>.setConfig(
     // Optionally clear root
     if (clearRoot) {
         // clearRoot is equivalent to overriding with a completely empty root
-        val opCount = self.data.expiringRootAndOpCount.opCount;
-        self.data.expiringRootAndOpCount = ExpiringRootAndOpCount{
-            root: 0, // empty root
-            validUntil: 0,
-            opCount: opCount,
-            // TON-specific additions below to support the async environment
-            validAfter: blockchain.now(), // immediate
-            opFinalizationTimeout: 0,
-            opPendingReceiver: createAddressNone(),
-            opPendingBodyVal: 0
-        };
-        self.data.rootMetadata = RootMetadata{
-            chainId: globalId() as int256,
-            multiSig: contract.getAddress(),
-            preOpCount: opCount,
-            postOpCount: opCount,
-            overridePreviousRoot: true
+        val rootInfo = lazy RootInfo.fromCell(self.data.rootInfo);
+        val opCount = rootInfo.expiringRootAndOpCount.opCount;
+        self.data.rootInfo = RootInfo{
+            expiringRootAndOpCount: ExpiringRootAndOpCount{
+                root: 0, // empty root
+                validUntil: 0,
+                opCount,
+                // TON-specific additions below to support the async environment
+                opPendingInfo: OpPendingInfo{
+                    validAfter: blockchain.now(), // immediate
+                    opFinalizationTimeout: 0,
+                    opPendingReceiver: createAddressNone(),
+                    opPendingBodyVal: 0
+                }.toCell()
+            },
+            rootMetadata: RootMetadata{
+                chainId: globalId() as int256,
+                multiSig: contract.getAddress(),
+                preOpCount: opCount,
+                postOpCount: opCount,
+                overridePreviousRoot: true
+            }
         }.toCell();
     }
 
@@ -1046,18 +1083,25 @@ fun MCMS<T>.getConfig(self): Config {
 
 /// Returns the current op count, i.e., the number of ops in the current expiring root.
 fun MCMS<T>.getOpCount(self): uint40 {
-    return self.data.expiringRootAndOpCount.opCount;
+    val rootInfo = lazy RootInfo.fromCell(self.data.rootInfo);
+    return rootInfo.expiringRootAndOpCount.opCount;
 }
 
 /// Returns the current expiring root and its validUntil time.
 fun MCMS<T>.getRoot(self): (uint256, uint32) {
-    val expiringRootAndOpCount = self.data.expiringRootAndOpCount;
-    return (expiringRootAndOpCount.root, expiringRootAndOpCount.validUntil);
+    val rootInfo = lazy RootInfo.fromCell(self.data.rootInfo);
+    return (rootInfo.expiringRootAndOpCount.root, rootInfo.expiringRootAndOpCount.validUntil);
+}
+
+// Returns the current pending operation information.
+fun MCMS<T>.getOpPendingInfo(self): OpPendingInfo {
+    val rootInfo = lazy RootInfo.fromCell(self.data.rootInfo);
+    return OpPendingInfo.fromCell(rootInfo.expiringRootAndOpCount.opPendingInfo);
 }
 
 /// Returns the current metadata about the root, which is stored as one of the leaves.
 fun MCMS<T>.getRootMetadata(self): RootMetadata {
-    return RootMetadata.fromCell(self.data.rootMetadata);
+    return RootInfo.fromCell(self.data.rootInfo).rootMetadata;
 }
 
 // --- Message handlers ---
@@ -1073,7 +1117,7 @@ fun MCMS<T>.onInternalMessage(mutate self, msgSender: address, msgValue: coins, 
         MCMS_SetRoot => {
             // TODO: make opFinalizationTimeout configurable
             self.setRoot(msgSender, msg.queryId, msg.root, msg.validUntil, msg.metadata,
-                Iterator<uint256>.new(msg.metadataProof), msg.signatures);
+                Iterator<uint256>.new(msg.metadataProof), msg.signatures, msg.opFinalizationTimeout);
         }
         MCMS_Execute => {
             self.execute(msgSender, msg.queryId, Op.fromCell(msg.op),
@@ -1099,6 +1143,12 @@ fun onBouncedMessage(in: InMessageBounced) {
     // Load the contract storage as MCMS and handle the bounced message
     var mcms = MCMS<bool>.load();
 
+    var rootInfo = lazy RootInfo.fromCell(mcms.data.rootInfo);
+    var opPendingInfo = lazy OpPendingInfo.fromCell(rootInfo.expiringRootAndOpCount.opPendingInfo);
+
+    debug.printString("BOUNCE");
+    debug.print(in.bouncedBody);
+
     // If the op was already finalized, we need to drop the bounce, and mark the root invalid.
     //
     // This is because subsequent operations might already be executed, and we're not at the
@@ -1106,9 +1156,10 @@ fun onBouncedMessage(in: InMessageBounced) {
     //
     // This is why critical operation sequences need to be commited with a timeout
     // which will allow enough time for them to be bounced and subsequently retried.
-    if (mcms.data.expiringRootAndOpCount.validAfter < blockchain.now()) {
+    if (opPendingInfo.validAfter < blockchain.now()) {
         // TODO: maybe we can also store and check opCount to see if subsequent ops were executed in the meantime
-        mcms.data.expiringRootAndOpCount.validUntil = blockchain.now(); // expire root immediately
+        rootInfo.expiringRootAndOpCount.validUntil = blockchain.now(); // expire root immediately
+        mcms.data.rootInfo = rootInfo.toCell();
         mcms.data.storeAsContractData();
         return;
     }
@@ -1116,10 +1167,11 @@ fun onBouncedMessage(in: InMessageBounced) {
     // Check the bounced message against the stored pending operation
     // If the received bounce does NOT equal expected, mark the root invalid.
     val bouncedBodyVal = extractBouncedBody(in.bouncedBody.skipBouncedPrefix());
-    if (mcms.data.expiringRootAndOpCount.opPendingReceiver != in.senderAddress 
-        || mcms.data.expiringRootAndOpCount.opPendingBodyVal != bouncedBodyVal) {
+    if (opPendingInfo.opPendingReceiver != in.senderAddress
+        || opPendingInfo.opPendingBodyVal != bouncedBodyVal) {
         // Mark root in error state (recover with new root + bypass)
-        mcms.data.expiringRootAndOpCount.validUntil = blockchain.now(); // expire root immediately
+        rootInfo.expiringRootAndOpCount.validUntil = blockchain.now(); // expire root immediately
+        mcms.data.rootInfo = rootInfo.toCell();
         mcms.data.storeAsContractData();
         return;
     }
@@ -1134,10 +1186,13 @@ fun onBouncedMessage(in: InMessageBounced) {
     // }
 
     // If the received bounce equals expected, revert state (allow op retry)
-    mcms.data.expiringRootAndOpCount.opCount = mcms.data.expiringRootAndOpCount.opCount - 1;
-    mcms.data.expiringRootAndOpCount.validAfter = blockchain.now(); // can be retried immediately
-    mcms.data.expiringRootAndOpCount.opPendingReceiver = createAddressNone();
-    mcms.data.expiringRootAndOpCount.opPendingBodyVal = 0;
+    rootInfo.expiringRootAndOpCount.opCount = rootInfo.expiringRootAndOpCount.opCount - 1;
+    opPendingInfo.validAfter = blockchain.now(); // can be retried immediately
+    opPendingInfo.opPendingReceiver = createAddressNone();
+    opPendingInfo.opPendingBodyVal = 0;
+
+    rootInfo.expiringRootAndOpCount.opPendingInfo = opPendingInfo.toCell();
+    mcms.data.rootInfo = rootInfo.toCell();
     mcms.data.storeAsContractData();
 }
 
@@ -1169,6 +1224,11 @@ get fun getOpCount(): uint40 {
 /// @see <MCMS<T>.getRoot>
 get fun getRoot(): (uint256, uint32) {
     return MCMS<bool>.load().getRoot();
+}
+
+/// @see <MCMS<T>.getOpPendingInfo>
+get fun getOpPendingInfo(): OpPendingInfo {
+    return MCMS<bool>.load().getOpPendingInfo();
 }
 
 /// @see <MCMS<T>.getRootMetadata>

--- a/contracts/contracts/mcms/mcms.tolk
+++ b/contracts/contracts/mcms/mcms.tolk
@@ -1,6 +1,7 @@
 tolk 1.0
 
 import "@stdlib/tvm-dicts";
+import "@stdlib/gas-payments";
 
 import "../lib/utils";
 import "../lib/access/ownable_2step.tolk";
@@ -330,6 +331,9 @@ const ERROR_SIGNED_HASH_ALREADY_SEEN = 121;
 
 /// @notice Thrown when the root has not been finalized yet (can't execute next op before finalization).
 const ERROR_ROOT_NOT_FINALIZED = 122;
+
+/// @notice Thrown when the provided op.value is insufficient (min required value not met).
+const ERROR_INSUFFICIENT_VALUE = 123;
 
 // --- Constants - storage ---
 
@@ -796,6 +800,14 @@ fun MCMS<T>.execute(
         throw ERROR_WRONG_NONCE;
     }
 
+    // We enforce a minimum amount of TON op.value trying to ensure the receiver gets at least enough gas for
+    // fee validation + a bounce, and avoid out of gas errors in which cases a message will not bounce.
+    val workchain = contract.getAddress().getWorkchain();
+    val minValue = calculateGasFee(workchain, DEFAULT_MESSAGE_FWD_BUDGET_GAS_UNITS);
+    if (op.value < minValue) {
+        throw ERROR_INSUFFICIENT_VALUE;
+    }
+
     // verify that the op exists in the merkle tree
     // Notice: we use the standard sha256 hash function to hash the leaf.
     val hashedLeaf =
@@ -835,14 +847,12 @@ fun MCMS<T>.execute(
         rootMetadata
     }.toCell();
 
-    // TODO: should we enforce a minimum amount of TON op.value here,
-    // so the receiver at least has enough for gas fee validation + a bounce?
     self._execute(op.to, op.value, op.data);
 
     // Reply back to sender
     createMessage({
         bounce: false,
-        value: DEFAULT_MESSAGE_BUDGET_FEE, // send small value as gas budget, keep the rest
+        value: minValue, // send small value as gas budget, keep the rest
         dest: sender,
         body: MCMS_OpExecuted{queryId, nonce: op.nonce, to: op.to, data: op.data, value: op.value}
     }).send(SEND_MODE_REGULAR);

--- a/contracts/contracts/mcms/rbac_timelock.tolk
+++ b/contracts/contracts/mcms/rbac_timelock.tolk
@@ -70,7 +70,7 @@ import "../lib/access/access_control";
 /// - `bypassers`: accounts to be granted bypasser role
 ///
 struct (0x4982fcfd) Timelock_Init {
-    /// Query ID of the change owner request.
+    /// Query ID of the change request.
     queryId: uint64;
 
     /// Minimum delay in seconds for future operations.
@@ -90,7 +90,7 @@ struct (0x4982fcfd) Timelock_Init {
 /// Contract might receive/hold TON as part of the maintenance process.
 ///
 struct (0xfee62ba6) Timelock_TopUp {
-    /// Query ID of the change owner request.
+    /// Query ID of the change request.
     queryId: uint64;
 }
 
@@ -104,7 +104,7 @@ struct (0xfee62ba6) Timelock_TopUp {
 /// - all payloads must not start with a blocked function selector.
 ///
 struct (0x094718f4) Timelock_ScheduleBatch {
-    /// Query ID of the change owner request.
+    /// Query ID of the change request.
     queryId: uint64;
 
     // Array of calls to be scheduled
@@ -124,7 +124,7 @@ struct (0x094718f4) Timelock_ScheduleBatch {
 /// - the caller must have the 'canceller' or 'admin' role.
 ///
 struct (0xaf3bf1d0) Timelock_Cancel {
-    /// Query ID of the change owner request.
+    /// Query ID of the change request.
     queryId: uint64;
 
     /// ID of the operation to cancel.
@@ -140,7 +140,7 @@ struct (0xaf3bf1d0) Timelock_Cancel {
 /// - the caller must have the 'executor' or 'admin' role.
 ///
 struct (0x6e9Bf263) Timelock_ExecuteBatch {
-    /// Query ID of the change owner request.
+    /// Query ID of the change request.
     queryId: uint64;
 
     // Array of calls to be scheduled
@@ -160,7 +160,7 @@ struct (0x6e9Bf263) Timelock_ExecuteBatch {
 /// - the caller must have the 'admin' role.
 ///
 struct (0x7a57a45c) Timelock_UpdateDelay {
-    /// Query ID of the change owner request.
+    /// Query ID of the change request.
     queryId: uint64;
 
     /// New minimum delay in seconds for future operations.
@@ -179,7 +179,7 @@ struct (0x7a57a45c) Timelock_UpdateDelay {
 /// - the caller must have the 'admin' role.
 ///
 struct (0x2637af77) Timelock_BlockFunctionSelector {
-    /// Query ID of the change owner request.
+    /// Query ID of the change request.
     queryId: uint64;
 
     /// Function selector to block.
@@ -193,7 +193,7 @@ struct (0x2637af77) Timelock_BlockFunctionSelector {
 /// - the caller must have the 'admin' role.
 ///
 struct (0x26f19f4e) Timelock_UnblockFunctionSelector {
-    /// Query ID of the change owner request.
+    /// Query ID of the change request.
     queryId: uint64;
 
     /// Function selector to unblock.
@@ -209,7 +209,7 @@ struct (0x26f19f4e) Timelock_UnblockFunctionSelector {
 /// - the caller must have the 'bypasser' or 'admin' role.
 ///
 struct (0xbb0e9f7d) Timelock_BypasserExecuteBatch {
-    /// Query ID of the change owner request.
+    /// Query ID of the change request.
     queryId: uint64;
 
     /// Array of calls to be scheduled
@@ -243,7 +243,7 @@ type Timelock_OutMessage = Timelock_BatchScheduled
 
 /// @dev Sent back to sender after a batch is scheduled.
 struct (0xdf65b59e) Timelock_BatchScheduled {
-    /// Query ID of the change owner request.
+    /// Query ID of the change request.
     queryId: uint64;
 
     /// ID of the batch that was scheduled.
@@ -254,7 +254,7 @@ struct (0xdf65b59e) Timelock_BatchScheduled {
 
 /// @dev Emitted when a call is scheduled as part of operation `id`.
 struct (0xc55fca54) Timelock_CallScheduled {
-    /// Query ID of the change owner request.
+    /// Query ID of the change request.
     queryId: uint64;
 
     /// ID of the batch for the operation that was scheduled.
@@ -270,7 +270,7 @@ struct (0xc55fca54) Timelock_CallScheduled {
 
 /// @dev Sent back to sender after a batch is executed.
 struct (0xa941ea1a) Timelock_BatchExecuted {
-    /// Query ID of the change owner request.
+    /// Query ID of the change request.
     queryId: uint64;
 
     /// ID of the batch that was executed.
@@ -279,7 +279,7 @@ struct (0xa941ea1a) Timelock_BatchExecuted {
 
 /// @dev Emitted when a call is performed as part of operation `id`.
 struct (0x49ea5d0e) Timelock_CallExecuted {
-    /// Query ID of the change owner request.
+    /// Query ID of the change request.
     queryId: uint64;
 
     /// ID of the batch for the operation that was executed.
@@ -292,13 +292,13 @@ struct (0x49ea5d0e) Timelock_CallExecuted {
 
 /// @dev Sent back to sender after a batch is executed via bypasser escape hatch.
 struct (0x539b4214) Timelock_BypasserBatchExecuted {
-    /// Query ID of the change owner request.
+    /// Query ID of the change request.
     queryId: uint64;
 }
 
 /// @dev Emitted when a call is performed via bypasser.
 struct (0x9c7f3010) Timelock_BypasserCallExecuted {
-    /// Query ID of the change owner request.
+    /// Query ID of the change request.
     queryId: uint64;
 
     /// Index of the call in the batch.
@@ -310,7 +310,7 @@ struct (0x9c7f3010) Timelock_BypasserCallExecuted {
 
 /// @dev Emitted when operation `id` is cancelled.
 struct (0x580e80f2) Timelock_Canceled {
-    /// Query ID of the change owner request.
+    /// Query ID of the change request.
     queryId: uint64;
 
     /// ID of the cancelled operation.
@@ -319,7 +319,7 @@ struct (0x580e80f2) Timelock_Canceled {
 
 /// @dev Emitted when the minimum delay for future operations is modified.
 struct (0x904b14e0) Timelock_MinDelayChange {
-    /// Query ID of the change owner request.
+    /// Query ID of the change request.
     queryId: uint64;
 
     /// Duration of the old minimum delay in seconds.
@@ -330,7 +330,7 @@ struct (0x904b14e0) Timelock_MinDelayChange {
 
 /// @dev Emitted when a function selector is blocked.
 struct (0x9c4d6d94) Timelock_FunctionSelectorBlocked {
-    /// Query ID of the change owner request.
+    /// Query ID of the change request.
     queryId: uint64;
 
     /// Function selector that was blocked.
@@ -339,7 +339,7 @@ struct (0x9c4d6d94) Timelock_FunctionSelectorBlocked {
 
 /// @dev Emitted when a function selector is unblocked.
 struct (0xf410a31b) Timelock_FunctionSelectorUnblocked {
-    /// Query ID of the change owner request.
+    /// Query ID of the change request.
     queryId: uint64;
 
     /// Function selector that was unblocked.

--- a/contracts/src/mcms/merkle-proof.ts
+++ b/contracts/src/mcms/merkle-proof.ts
@@ -15,6 +15,7 @@ export function build(
   validUntil: bigint,
   metadata: mcms.RootMetadata,
   ops: mcms.Op[],
+  opFinalizationTimeout: bigint,
 ): [mcms.SetRoot, OpProofs] {
   const leaves = constructLeaves(ops, metadata)
 
@@ -39,6 +40,7 @@ export function build(
       metadata,
       metadataProof: asSnakeData<bigint>(metadataProof, encodeProof),
       signatures: asSnakeData<mcms.Signature>(signatures, encodeSignature),
+      opFinalizationTimeout,
     },
     opProofs,
   ]

--- a/contracts/tests/mcms/Integration.spec.ts
+++ b/contracts/tests/mcms/Integration.spec.ts
@@ -66,6 +66,9 @@ describe('MCMS - IntegrationTest', () => {
 
   const MIN_DELAY = 24n * 60n * 60n
 
+  // Notice: no finalization timeout between ops
+  const OP_FINALIZATION_TIMEOUT_ZERO = 0n
+
   let signerKeyPairs: KeyPair[] = []
 
   beforeEach(async () => {
@@ -554,7 +557,13 @@ describe('MCMS - IntegrationTest', () => {
           }),
         },
       ]
-      const [setRoot, opProofs] = merkleProof.build(signers, validUntil, metadata, ops)
+      const [setRoot, opProofs] = merkleProof.build(
+        signers,
+        validUntil,
+        metadata,
+        ops,
+        OP_FINALIZATION_TIMEOUT_ZERO,
+      )
 
       const r = await bind.mcmsPropose.sendInternal(
         acc.deployer.getSender(),
@@ -673,7 +682,13 @@ describe('MCMS - IntegrationTest', () => {
         },
       ]
 
-      const [setRoot, opProofs] = merkleProof.build(signers, validUntil, metadata, ops)
+      const [setRoot, opProofs] = merkleProof.build(
+        signers,
+        validUntil,
+        metadata,
+        ops,
+        OP_FINALIZATION_TIMEOUT_ZERO,
+      )
 
       const r = await bind.mcmsPropose.sendInternal(
         acc.deployer.getSender(),
@@ -798,7 +813,13 @@ describe('MCMS - IntegrationTest', () => {
         },
       ]
 
-      const [setRoot, opProofs] = merkleProof.build(signers, validUntil, metadata, ops)
+      const [setRoot, opProofs] = merkleProof.build(
+        signers,
+        validUntil,
+        metadata,
+        ops,
+        OP_FINALIZATION_TIMEOUT_ZERO,
+      )
 
       const r = await bind.mcmsBypass.sendInternal(
         acc.deployer.getSender(),
@@ -917,7 +938,13 @@ describe('MCMS - IntegrationTest', () => {
         },
       ]
 
-      const [setRoot, opProofs] = merkleProof.build(signers, validUntil, metadata, ops)
+      const [setRoot, opProofs] = merkleProof.build(
+        signers,
+        validUntil,
+        metadata,
+        ops,
+        OP_FINALIZATION_TIMEOUT_ZERO,
+      )
 
       const r = await bind.mcmsPropose.sendInternal(
         acc.deployer.getSender(),
@@ -991,7 +1018,13 @@ describe('MCMS - IntegrationTest', () => {
           },
         ]
 
-        const [setRoot, opProofs] = merkleProof.build(signers, validUntil, metadata, ops)
+        const [setRoot, opProofs] = merkleProof.build(
+          signers,
+          validUntil,
+          metadata,
+          ops,
+          OP_FINALIZATION_TIMEOUT_ZERO,
+        )
 
         const r = await bind.mcmsVeto.sendInternal(
           acc.deployer.getSender(),
@@ -1122,7 +1155,13 @@ describe('MCMS - IntegrationTest', () => {
         },
       ]
 
-      const [setRoot, opProofs] = merkleProof.build(signers, validUntil, metadata, ops)
+      const [setRoot, opProofs] = merkleProof.build(
+        signers,
+        validUntil,
+        metadata,
+        ops,
+        OP_FINALIZATION_TIMEOUT_ZERO,
+      )
 
       const r = await bind.mcmsPropose.sendInternal(
         acc.deployer.getSender(),

--- a/contracts/tests/mcms/MCMS.spec.ts
+++ b/contracts/tests/mcms/MCMS.spec.ts
@@ -59,12 +59,14 @@ describe('MCMS', () => {
     expect(mcms.opcodes.in.Execute).toBe(0x9b9ce96a)
     expect(mcms.opcodes.in.SetConfig).toBe(0x89277f4b)
     expect(mcms.opcodes.in.SubmitErrorReport).toBe(0x4b3af0b5)
+    expect(mcms.opcodes.in.TransferOracleRole).toBe(0xf275742f)
 
     // Out opcodes
     expect(mcms.opcodes.out.NewRoot).toBe(0xa6533a3d)
     expect(mcms.opcodes.out.ConfigSet).toBe(0xd80be574)
     expect(mcms.opcodes.out.OpExecuted).toBe(0x7cf37cbf)
     expect(mcms.opcodes.out.ErrorReportedSubmitted).toBe(0xbbc4deb4)
+    expect(mcms.opcodes.out.OracleRoleTransferred).toBe(0xff4176a3)
   })
 
   it('should deploy', async () => {

--- a/contracts/tests/mcms/MCMS.spec.ts
+++ b/contracts/tests/mcms/MCMS.spec.ts
@@ -58,11 +58,13 @@ describe('MCMS', () => {
     expect(mcms.opcodes.in.SetRoot).toBe(0xe7fabde3)
     expect(mcms.opcodes.in.Execute).toBe(0x9b9ce96a)
     expect(mcms.opcodes.in.SetConfig).toBe(0x89277f4b)
+    expect(mcms.opcodes.in.SubmitErrorReport).toBe(0x4b3af0b5)
 
     // Out opcodes
     expect(mcms.opcodes.out.NewRoot).toBe(0xa6533a3d)
     expect(mcms.opcodes.out.ConfigSet).toBe(0xd80be574)
     expect(mcms.opcodes.out.OpExecuted).toBe(0x7cf37cbf)
+    expect(mcms.opcodes.out.ErrorReportedSubmitted).toBe(0xbbc4deb4)
   })
 
   it('should deploy', async () => {

--- a/contracts/tests/mcms/ManyChainMultiSigBaseTest.ts
+++ b/contracts/tests/mcms/ManyChainMultiSigBaseTest.ts
@@ -236,6 +236,7 @@ export class MCMSBaseTestSetup {
         owner: this.acc.multisigOwner.address,
         pendingOwner: null,
       },
+      oracle: ZERO_ADDRESS,
       signers: new Map<bigint, Buffer>(),
       config: {
         signers: new Map<number, Buffer>(),

--- a/contracts/tests/mcms/ManyChainMultiSigBaseTest.ts
+++ b/contracts/tests/mcms/ManyChainMultiSigBaseTest.ts
@@ -10,7 +10,12 @@ import { merkleProof } from '../../src/mcms'
 import * as counter from '../../wrappers/examples/Counter'
 
 import { crc32 } from 'zlib'
-import { generateEd25519KeyPair, asSnakeData, uint8ArrayToBigInt } from '../../src/utils'
+import {
+  generateEd25519KeyPair,
+  asSnakeData,
+  uint8ArrayToBigInt,
+  ZERO_ADDRESS,
+} from '../../src/utils'
 
 export type MCMSTestCode = {
   mcms: Cell
@@ -52,6 +57,8 @@ export class MCMSBaseTestSetup {
   static readonly GROUP3_PARENT = 0
   static readonly TEST_CHAIN_ID = -239n // TODO: blockchain global chain ID (will need to be signed int)
   static readonly TEST_VALID_UNTIL = 1000000
+
+  static readonly OP_FINALIZATION_TIMEOUT_ZERO = 0n
 
   blockchain: Blockchain
   code: MCMSTestCode
@@ -236,26 +243,32 @@ export class MCMSBaseTestSetup {
         groupParents: new Map<number, number>(),
       },
       seenSignedHashes: new Map<bigint, boolean>(),
-      expiringRootAndOpCount: {
-        root: 0n,
-        validUntil: 0n,
-        opCount: 0n,
-        validAfter: 0n,
-        opFinalizationTimeout: 0n,
-      },
-      rootMetadata: {
-        chainId: MCMSBaseTestSetup.TEST_CHAIN_ID,
-        multiSig: Address.parse('EQDtFpEwcFAEcRe5mLVh2N6C0x-_hJEM7W61_JLnSF74p4q2'), // Will be updated after deployment
-        preOpCount: 0n,
-        postOpCount: 0n,
-        overridePreviousRoot: false,
+      rootInfo: {
+        expiringRootAndOpCount: {
+          root: 0n,
+          validUntil: 0n,
+          opCount: 0n,
+          opPendingInfo: {
+            validAfter: 0n,
+            opFinalizationTimeout: MCMSBaseTestSetup.OP_FINALIZATION_TIMEOUT_ZERO,
+            opPendingReceiver: ZERO_ADDRESS,
+            opPendingBodyVal: 0n,
+          },
+        },
+        rootMetadata: {
+          chainId: MCMSBaseTestSetup.TEST_CHAIN_ID,
+          multiSig: Address.parse('EQDtFpEwcFAEcRe5mLVh2N6C0x-_hJEM7W61_JLnSF74p4q2'), // Will be updated after deployment
+          preOpCount: 0n,
+          postOpCount: 0n,
+          overridePreviousRoot: false,
+        },
       },
     }
 
     this.bind.mcms = this.blockchain.openContract(mcms.ContractClient.newFrom(data, this.code.mcms))
 
     // Update the multiSig address in rootMetadata
-    data.rootMetadata.multiSig = this.bind.mcms.address
+    data.rootInfo.rootMetadata.multiSig = this.bind.mcms.address
   }
 
   /**
@@ -363,7 +376,7 @@ export class MCMSBaseTestSetup {
   /**
    * Create multiple test operations
    */
-  createTestOps(count: number): mcms.Op[] {
+  createTestOps(count: number, includeRevertingOp: boolean = true, startNonce = 0): mcms.Op[] {
     const ops: mcms.Op[] = []
     for (let i = 0; i < count; i++) {
       const value =
@@ -372,7 +385,14 @@ export class MCMSBaseTestSetup {
       {
         switch (i) {
           case MCMSBaseSetRootAndExecuteTestSetup.REVERTING_OP_INDEX:
-            op = beginCell().storeUint(0xffffffff, 32).endCell()
+            if (includeRevertingOp) {
+              op = beginCell().storeUint(0xffffffff, 32).endCell()
+            } else {
+              op = counter.builder.message.in.setCount.encode({
+                queryId: BigInt(i + 1),
+                newCount: i,
+              })
+            }
             break
           case MCMSBaseSetRootAndExecuteTestSetup.VALUE_OP_INDEX:
             op = beginCell().endCell()
@@ -388,7 +408,7 @@ export class MCMSBaseTestSetup {
       ops.push({
         chainId: MCMSBaseTestSetup.TEST_CHAIN_ID,
         multiSig: this.bind.mcms.address,
-        nonce: BigInt(i),
+        nonce: BigInt(i + startNonce),
         to: this.bind.counter.address,
         value,
         data: op,
@@ -492,7 +512,9 @@ export class MCMSBaseSetRootAndExecuteTestSetup extends MCMSBaseTestSetup {
   /**
    * Set the initial root using merkle proof helper
    */
-  async setInitialRoot(): Promise<void> {
+  async setInitialRoot(rootMetadata = this.initialTestRootMetadata): Promise<void> {
+    this.initialTestRootMetadata = rootMetadata
+
     const signers = this.testSigners.map((s) => ({
       publicKey: s.keyPair.publicKey,
       sign: (data: Buffer<ArrayBufferLike>) => sign(data, s.keyPair.secretKey),
@@ -501,8 +523,9 @@ export class MCMSBaseSetRootAndExecuteTestSetup extends MCMSBaseTestSetup {
     const [setRoot, opProofs] = merkleProof.build(
       signers,
       BigInt(MCMSBaseSetRootAndExecuteTestSetup.TEST_VALID_UNTIL),
-      this.initialTestRootMetadata,
+      rootMetadata,
       this.testOps,
+      MCMSBaseTestSetup.OP_FINALIZATION_TIMEOUT_ZERO,
     )
 
     // Store the operation proofs for later use in execute tests
@@ -536,6 +559,7 @@ export class MCMSBaseSetRootAndExecuteTestSetup extends MCMSBaseTestSetup {
   // Execute all operations up to the post-op count limit to simulate setOpCount
   async executeOperationsUpTo(index: number) {
     for (let i = 0; i < index; i++) {
+      console.log(`Executing operation ${i}`)
       const executeBody = mcms.builder.message.in.execute.encode({
         queryId: BigInt(i + 1),
         op: mcms.builder.data.op.encode(this.testOps[i]),

--- a/contracts/tests/mcms/ManyChainMultiSigBaseTest.ts
+++ b/contracts/tests/mcms/ManyChainMultiSigBaseTest.ts
@@ -252,7 +252,7 @@ export class MCMSBaseTestSetup {
             validAfter: 0n,
             opFinalizationTimeout: MCMSBaseTestSetup.OP_FINALIZATION_TIMEOUT_ZERO,
             opPendingReceiver: ZERO_ADDRESS,
-            opPendingBodyVal: 0n,
+            opPendingBodyTruncated: 0n,
           },
         },
         rootMetadata: {

--- a/contracts/tests/mcms/ManyChainMultiSigBaseTest.ts
+++ b/contracts/tests/mcms/ManyChainMultiSigBaseTest.ts
@@ -381,30 +381,31 @@ export class MCMSBaseTestSetup {
     for (let i = 0; i < count; i++) {
       const value =
         i == MCMSBaseSetRootAndExecuteTestSetup.VALUE_OP_INDEX ? toNano('10') : toNano('0.10')
-      let op: Cell
+
+      // default op
+      let op = counter.builder.message.in.setCount.encode({
+        queryId: BigInt(i + startNonce),
+        newCount: i + startNonce,
+      })
+
       {
         switch (i) {
           case MCMSBaseSetRootAndExecuteTestSetup.REVERTING_OP_INDEX:
             if (includeRevertingOp) {
               op = beginCell().storeUint(0xffffffff, 32).endCell()
             } else {
-              op = counter.builder.message.in.setCount.encode({
-                queryId: BigInt(i + 1),
-                newCount: i,
-              })
+              // use default op
             }
             break
           case MCMSBaseSetRootAndExecuteTestSetup.VALUE_OP_INDEX:
             op = beginCell().endCell()
             break
           default:
-            op = counter.builder.message.in.setCount.encode({
-              queryId: BigInt(i + 1),
-              newCount: i,
-            })
+            // use default op
             break
         }
       }
+
       ops.push({
         chainId: MCMSBaseTestSetup.TEST_CHAIN_ID,
         multiSig: this.bind.mcms.address,
@@ -414,6 +415,7 @@ export class MCMSBaseTestSetup {
         data: op,
       })
     }
+
     return ops
   }
 
@@ -576,7 +578,6 @@ export class MCMSBaseSetRootAndExecuteTestSetup extends MCMSBaseTestSetup {
   // Execute all operations up to the post-op count limit to simulate setOpCount
   async executeOperationsUpTo(index: number) {
     for (let i = 0; i < index; i++) {
-      console.log(`Executing operation ${i}`)
       const executeBody = mcms.builder.message.in.execute.encode({
         queryId: BigInt(i + 1),
         op: mcms.builder.data.op.encode(this.testOps[i]),

--- a/contracts/tests/mcms/ManyChainMultiSigBaseTest.ts
+++ b/contracts/tests/mcms/ManyChainMultiSigBaseTest.ts
@@ -502,6 +502,23 @@ export class MCMSBaseSetRootAndExecuteTestSetup extends MCMSBaseTestSetup {
     this.testOps = this.createTestOps(MCMSBaseSetRootAndExecuteTestSetup.OPS_NUM)
   }
 
+  // Recreate test operations (skip reverting op for this test setup)
+  async recreateTestOpsNoRevertingOp(): Promise<void> {
+    // Notice: needs setting new root with new metadata
+    const includeRevertingOp = false
+    this.testOps = this.createTestOps(
+      MCMSBaseSetRootAndExecuteTestSetup.OPS_NUM,
+      includeRevertingOp,
+    )
+    await this.setInitialRoot(
+      this.createTestRootMetadata(
+        0n,
+        BigInt(MCMSBaseSetRootAndExecuteTestSetup.OPS_NUM),
+        true, // override root
+      ),
+    )
+  }
+
   /**
    * Get the leaf index for a specific operation
    */

--- a/contracts/tests/mcms/ManyChainMultiSigBaseTest.ts
+++ b/contracts/tests/mcms/ManyChainMultiSigBaseTest.ts
@@ -240,6 +240,8 @@ export class MCMSBaseTestSetup {
         root: 0n,
         validUntil: 0n,
         opCount: 0n,
+        validAfter: 0n,
+        opFinalizationTimeout: 0n,
       },
       rootMetadata: {
         chainId: MCMSBaseTestSetup.TEST_CHAIN_ID,

--- a/contracts/tests/mcms/ManyChainMultiSigExecute.spec.ts
+++ b/contracts/tests/mcms/ManyChainMultiSigExecute.spec.ts
@@ -2,7 +2,7 @@ import { toNano, beginCell } from '@ton/core'
 import '@ton/test-utils'
 import { MCMSBaseSetRootAndExecuteTestSetup, MCMSTestCode } from './ManyChainMultiSigBaseTest'
 import * as mcms from '../../wrappers/mcms/MCMS'
-import { asSnakeData } from '../../src/utils'
+import { asSnakeData, ZERO_ADDRESS } from '../../src/utils'
 import { ERROR_UNAUTHORIZED_SIGNER } from '../../wrappers/libraries/ocr/ExitCodes'
 
 describe('MCMS - ManyChainMultiSigExecuteTest', () => {
@@ -330,6 +330,13 @@ describe('MCMS - ManyChainMultiSigExecuteTest', () => {
     // Verify we're (back) at the correct op count, the error was handled and we can retry
     currentOpCount = await baseTest.bind.mcms.getOpCount()
     expect(currentOpCount).toEqual(BigInt(MCMSBaseSetRootAndExecuteTestSetup.REVERTING_OP_INDEX))
+
+    // Check OpPendingInfo is cleared after a bounce
+    const opPendingInfo = await baseTest.bind.mcms.getOpPendingInfo()
+    expect(opPendingInfo).toBeDefined()
+    expect(opPendingInfo.validAfter).toBeGreaterThan(0)
+    expect(opPendingInfo.opPendingReceiver).toEqualAddress(ZERO_ADDRESS)
+    expect(opPendingInfo.opPendingBodyVal).toEqual(0n)
   })
 
   it('should handle value operations correctly - insufficient balance', async () => {

--- a/contracts/tests/mcms/ManyChainMultiSigExecute.spec.ts
+++ b/contracts/tests/mcms/ManyChainMultiSigExecute.spec.ts
@@ -28,21 +28,7 @@ describe('MCMS - ManyChainMultiSigExecuteTest', () => {
       mcms.builder.message.in.topUp.encode({ queryId: 1n }),
     )
 
-    // Recreate test operations (skip reverting op for this test)
-    // Notice: needs setting new root with new metadata
-    const includeRevertingOp = false
-    baseTest.testOps = baseTest.createTestOps(
-      MCMSBaseSetRootAndExecuteTestSetup.OPS_NUM,
-      includeRevertingOp,
-    )
-    await baseTest.setInitialRoot(
-      baseTest.createTestRootMetadata(
-        0n,
-        BigInt(MCMSBaseSetRootAndExecuteTestSetup.OPS_NUM),
-        true, // override root
-      ),
-    )
-
+    await baseTest.recreateTestOpsNoRevertingOp()
     await baseTest.executeOperationsUpTo(MCMSBaseSetRootAndExecuteTestSetup.OPS_NUM)
 
     // Verify we've reached the post-op count
@@ -347,20 +333,7 @@ describe('MCMS - ManyChainMultiSigExecuteTest', () => {
   })
 
   it('should handle value operations correctly - insufficient balance', async () => {
-    // Recreate test operations (skip reverting op for this test)
-    // Notice: needs setting new root with new metadata
-    const includeRevertingOp = false
-    baseTest.testOps = baseTest.createTestOps(
-      MCMSBaseSetRootAndExecuteTestSetup.OPS_NUM,
-      includeRevertingOp,
-    )
-    await baseTest.setInitialRoot(
-      baseTest.createTestRootMetadata(
-        0n,
-        BigInt(MCMSBaseSetRootAndExecuteTestSetup.OPS_NUM),
-        true, // override root
-      ),
-    )
+    await baseTest.recreateTestOpsNoRevertingOp()
 
     // Check that MCMS contract has minimal balance initially
     const mcmsContract = await baseTest.blockchain.getContract(baseTest.bind.mcms.address)
@@ -404,20 +377,7 @@ describe('MCMS - ManyChainMultiSigExecuteTest', () => {
   })
 
   it('should handle value operations correctly - with sufficient balance', async () => {
-    // Recreate test operations (skip reverting op for this test)
-    // Notice: needs setting new root with new metadata
-    const includeRevertingOp = false
-    baseTest.testOps = baseTest.createTestOps(
-      MCMSBaseSetRootAndExecuteTestSetup.OPS_NUM,
-      includeRevertingOp,
-    )
-    await baseTest.setInitialRoot(
-      baseTest.createTestRootMetadata(
-        0n,
-        BigInt(MCMSBaseSetRootAndExecuteTestSetup.OPS_NUM),
-        true, // override root
-      ),
-    )
+    await baseTest.recreateTestOpsNoRevertingOp()
 
     // Execute operations up to the value operation index
     await baseTest.executeOperationsUpTo(MCMSBaseSetRootAndExecuteTestSetup.VALUE_OP_INDEX)

--- a/contracts/tests/mcms/ManyChainMultiSigExecute.spec.ts
+++ b/contracts/tests/mcms/ManyChainMultiSigExecute.spec.ts
@@ -336,7 +336,7 @@ describe('MCMS - ManyChainMultiSigExecuteTest', () => {
     expect(opPendingInfo).toBeDefined()
     expect(opPendingInfo.validAfter).toBeGreaterThan(0)
     expect(opPendingInfo.opPendingReceiver).toEqualAddress(ZERO_ADDRESS)
-    expect(opPendingInfo.opPendingBodyVal).toEqual(0n)
+    expect(opPendingInfo.opPendingBodyTruncated).toEqual(0n)
   })
 
   it('should handle value operations correctly - insufficient balance', async () => {

--- a/contracts/tests/mcms/ManyChainMultiSigExecute.spec.ts
+++ b/contracts/tests/mcms/ManyChainMultiSigExecute.spec.ts
@@ -28,6 +28,21 @@ describe('MCMS - ManyChainMultiSigExecuteTest', () => {
       mcms.builder.message.in.topUp.encode({ queryId: 1n }),
     )
 
+    // Recreate test operations (skip reverting op for this test)
+    // Notice: needs setting new root with new metadata
+    const includeRevertingOp = false
+    baseTest.testOps = baseTest.createTestOps(
+      MCMSBaseSetRootAndExecuteTestSetup.OPS_NUM,
+      includeRevertingOp,
+    )
+    await baseTest.setInitialRoot(
+      baseTest.createTestRootMetadata(
+        0n,
+        BigInt(MCMSBaseSetRootAndExecuteTestSetup.OPS_NUM),
+        true, // override root
+      ),
+    )
+
     await baseTest.executeOperationsUpTo(MCMSBaseSetRootAndExecuteTestSetup.OPS_NUM)
 
     // Verify we've reached the post-op count
@@ -296,7 +311,7 @@ describe('MCMS - ManyChainMultiSigExecuteTest', () => {
     await baseTest.executeOperationsUpTo(MCMSBaseSetRootAndExecuteTestSetup.REVERTING_OP_INDEX)
 
     // Verify we're at the correct op count
-    const currentOpCount = await baseTest.bind.mcms.getOpCount()
+    let currentOpCount = await baseTest.bind.mcms.getOpCount()
     expect(currentOpCount).toEqual(BigInt(MCMSBaseSetRootAndExecuteTestSetup.REVERTING_OP_INDEX))
 
     // Now try to execute the reverting operation
@@ -325,9 +340,28 @@ describe('MCMS - ManyChainMultiSigExecuteTest', () => {
     })
 
     // TODO check emit or reply with the failed error
+
+    // Verify we're (back) at the correct op count, the error was handled and we can retry
+    currentOpCount = await baseTest.bind.mcms.getOpCount()
+    expect(currentOpCount).toEqual(BigInt(MCMSBaseSetRootAndExecuteTestSetup.REVERTING_OP_INDEX))
   })
 
   it('should handle value operations correctly - insufficient balance', async () => {
+    // Recreate test operations (skip reverting op for this test)
+    // Notice: needs setting new root with new metadata
+    const includeRevertingOp = false
+    baseTest.testOps = baseTest.createTestOps(
+      MCMSBaseSetRootAndExecuteTestSetup.OPS_NUM,
+      includeRevertingOp,
+    )
+    await baseTest.setInitialRoot(
+      baseTest.createTestRootMetadata(
+        0n,
+        BigInt(MCMSBaseSetRootAndExecuteTestSetup.OPS_NUM),
+        true, // override root
+      ),
+    )
+
     // Check that MCMS contract has minimal balance initially
     const mcmsContract = await baseTest.blockchain.getContract(baseTest.bind.mcms.address)
     expect(mcmsContract.balance).toBeLessThanOrEqual(toNano('2')) // Should be very low (just deployment funds)
@@ -370,6 +404,21 @@ describe('MCMS - ManyChainMultiSigExecuteTest', () => {
   })
 
   it('should handle value operations correctly - with sufficient balance', async () => {
+    // Recreate test operations (skip reverting op for this test)
+    // Notice: needs setting new root with new metadata
+    const includeRevertingOp = false
+    baseTest.testOps = baseTest.createTestOps(
+      MCMSBaseSetRootAndExecuteTestSetup.OPS_NUM,
+      includeRevertingOp,
+    )
+    await baseTest.setInitialRoot(
+      baseTest.createTestRootMetadata(
+        0n,
+        BigInt(MCMSBaseSetRootAndExecuteTestSetup.OPS_NUM),
+        true, // override root
+      ),
+    )
+
     // Execute operations up to the value operation index
     await baseTest.executeOperationsUpTo(MCMSBaseSetRootAndExecuteTestSetup.VALUE_OP_INDEX)
 

--- a/contracts/tests/mcms/ManyChainMultiSigExecute.spec.ts
+++ b/contracts/tests/mcms/ManyChainMultiSigExecute.spec.ts
@@ -1,9 +1,8 @@
-import { toNano, beginCell } from '@ton/core'
+import { toNano } from '@ton/core'
 import '@ton/test-utils'
 import { MCMSBaseSetRootAndExecuteTestSetup, MCMSTestCode } from './ManyChainMultiSigBaseTest'
 import * as mcms from '../../wrappers/mcms/MCMS'
-import { asSnakeData, ZERO_ADDRESS } from '../../src/utils'
-import { ERROR_UNAUTHORIZED_SIGNER } from '../../wrappers/libraries/ocr/ExitCodes'
+import { ZERO_ADDRESS } from '../../src/utils'
 
 describe('MCMS - ManyChainMultiSigExecuteTest', () => {
   let baseTest: MCMSBaseSetRootAndExecuteTestSetup

--- a/contracts/tests/mcms/ManyChainMultiSigExecuteErrorOracle.spec.ts
+++ b/contracts/tests/mcms/ManyChainMultiSigExecuteErrorOracle.spec.ts
@@ -27,9 +27,7 @@ describe('MCMS - ManyChainMultiSigExecuteErrorOracleTest', () => {
     acc = { oracle: await baseTest.blockchain.treasury('oracle') }
   })
 
-  it('should allow owner to transfer oracle role', async () => {
-    expect(await baseTest.bind.mcms.getOracle()).toEqualAddress(ZERO_ADDRESS)
-
+  const _setupOracleRole = async () => {
     const r = await baseTest.bind.mcms.sendInternal(
       baseTest.acc.multisigOwner.getSender(),
       toNano('1'),
@@ -46,6 +44,12 @@ describe('MCMS - ManyChainMultiSigExecuteErrorOracleTest', () => {
     })
 
     expect(await baseTest.bind.mcms.getOracle()).toEqualAddress(acc.oracle.address)
+  }
+
+  it('should allow owner to transfer oracle role', async () => {
+    expect(await baseTest.bind.mcms.getOracle()).toEqualAddress(ZERO_ADDRESS)
+
+    await _setupOracleRole()
   })
 
   it('should fail to transfer oracle role if not owner', async () => {
@@ -71,17 +75,7 @@ describe('MCMS - ManyChainMultiSigExecuteErrorOracleTest', () => {
   })
 
   it('should allow oracle to submit an error report and expire root', async () => {
-    // Setup oracle role
-    const r = await baseTest.bind.mcms.sendInternal(
-      baseTest.acc.multisigOwner.getSender(),
-      toNano('1'),
-      mcms.builder.message.in.transferOracleRole.encode({
-        queryId: 1n,
-        newOracle: acc.oracle.address,
-      }),
-    )
-
-    expect(await baseTest.bind.mcms.getOracle()).toEqualAddress(acc.oracle.address)
+    await _setupOracleRole()
 
     // Execute first operation
     const proof1 = baseTest.getProofForOp(0)
@@ -145,7 +139,93 @@ describe('MCMS - ManyChainMultiSigExecuteErrorOracleTest', () => {
     })
   })
 
-  it('should allow setRoot (new) after an error report was submitted', async () => {})
+  it('should allow setRoot (new) after an error report was submitted', async () => {
+    await _setupOracleRole()
+
+    // Execute first operation
+    const proof1 = baseTest.getProofForOp(0)
+
+    const execBody = mcms.builder.message.in.execute.encode({
+      queryId: 1n,
+      op: mcms.builder.data.op.encode(baseTest.testOps[0]),
+      proof: proof1,
+    })
+
+    const r1 = await baseTest.bind.mcms.sendInternal(
+      baseTest.acc.deployer.getSender(),
+      toNano('1'),
+      execBody,
+    )
+
+    expect(r1.transactions).toHaveTransaction({
+      from: baseTest.acc.deployer.address,
+      to: baseTest.bind.mcms.address,
+      success: true,
+    })
+
+    // Check that the op count was incremented
+    const opCount = await baseTest.bind.mcms.getOpCount()
+    expect(opCount).toEqual(baseTest.testOps[0].nonce + 1n)
+
+    // Submit an error report
+    const txHash = BigInt('0x' + r1.transactions[0].hash().toString('hex'))
+
+    const r2 = await baseTest.bind.mcms.sendInternal(
+      acc.oracle.getSender(),
+      toNano('1'),
+      mcms.builder.message.in.submitErrorReport.encode({
+        queryId: 1n,
+        op: mcms.builder.data.op.encode(baseTest.testOps[0]),
+        proof: proof1,
+        opTxHash: txHash,
+        errorTxHash: txHash,
+        errorCode: 1337,
+      }),
+    )
+
+    expect(r2.transactions).toHaveTransaction({
+      from: acc.oracle.address,
+      to: baseTest.bind.mcms.address,
+      success: true,
+    })
+
+    // Create and publish a new root
+    const includeRevertingOp = false
+    const startNonce = 1
+    baseTest.testOps = baseTest.createTestOps(
+      MCMSBaseSetRootAndExecuteTestSetup.OPS_NUM,
+      includeRevertingOp,
+      startNonce,
+    )
+    await baseTest.setInitialRoot(
+      baseTest.createTestRootMetadata(
+        1n,
+        BigInt(MCMSBaseSetRootAndExecuteTestSetup.OPS_NUM),
+        true, // override root
+      ),
+    )
+
+    // Try to execute the new op, new root
+    const proofNew = baseTest.getProofForOp(0)
+
+    const execBodyNew = mcms.builder.message.in.execute.encode({
+      queryId: 1n,
+      op: mcms.builder.data.op.encode(baseTest.testOps[0]),
+      proof: proofNew,
+    })
+
+    const r3 = await baseTest.bind.mcms.sendInternal(
+      baseTest.acc.deployer.getSender(),
+      toNano('1'),
+      execBodyNew,
+    )
+
+    expect(r3.transactions).toHaveTransaction({
+      from: baseTest.acc.deployer.address,
+      to: baseTest.bind.mcms.address,
+      success: true,
+    })
+  })
 
   it('should fail to submit error report if not oracle', async () => {})
 

--- a/contracts/tests/mcms/ManyChainMultiSigExecuteErrorOracle.spec.ts
+++ b/contracts/tests/mcms/ManyChainMultiSigExecuteErrorOracle.spec.ts
@@ -1,0 +1,153 @@
+import '@ton/test-utils'
+import { toNano } from '@ton/core'
+import { SandboxContract, TreasuryContract } from '@ton/sandbox'
+import { ZERO_ADDRESS } from '../../src/utils'
+import { MCMSBaseSetRootAndExecuteTestSetup, MCMSTestCode } from './ManyChainMultiSigBaseTest'
+
+import * as mcms from '../../wrappers/mcms/MCMS'
+import * as ownable2step from '../../wrappers/libraries/access/Ownable2Step'
+
+describe('MCMS - ManyChainMultiSigExecuteErrorOracleTest', () => {
+  let baseTest: MCMSBaseSetRootAndExecuteTestSetup
+  let code: MCMSTestCode
+
+  let acc: {
+    oracle: SandboxContract<TreasuryContract>
+  }
+
+  beforeAll(async () => {
+    code = await MCMSBaseSetRootAndExecuteTestSetup.compileContracts()
+  })
+
+  beforeEach(async () => {
+    baseTest = new MCMSBaseSetRootAndExecuteTestSetup()
+    baseTest.code = code
+    await baseTest.setupForSetRootAndExecute('test-execute')
+    await baseTest.setInitialRoot()
+    acc = { oracle: await baseTest.blockchain.treasury('oracle') }
+  })
+
+  it('should allow owner to transfer oracle role', async () => {
+    expect(await baseTest.bind.mcms.getOracle()).toEqualAddress(ZERO_ADDRESS)
+
+    const r = await baseTest.bind.mcms.sendInternal(
+      baseTest.acc.multisigOwner.getSender(),
+      toNano('1'),
+      mcms.builder.message.in.transferOracleRole.encode({
+        queryId: 1n,
+        newOracle: acc.oracle.address,
+      }),
+    )
+
+    expect(r.transactions).toHaveTransaction({
+      from: baseTest.acc.multisigOwner.address,
+      to: baseTest.bind.mcms.address,
+      success: true,
+    })
+
+    expect(await baseTest.bind.mcms.getOracle()).toEqualAddress(acc.oracle.address)
+  })
+
+  it('should fail to transfer oracle role if not owner', async () => {
+    expect(await baseTest.bind.mcms.getOracle()).toEqualAddress(ZERO_ADDRESS)
+
+    const r = await baseTest.bind.mcms.sendInternal(
+      baseTest.acc.deployer.getSender(),
+      toNano('1'),
+      mcms.builder.message.in.transferOracleRole.encode({
+        queryId: 1n,
+        newOracle: acc.oracle.address,
+      }),
+    )
+
+    expect(r.transactions).toHaveTransaction({
+      from: baseTest.acc.deployer.address,
+      to: baseTest.bind.mcms.address,
+      success: false,
+      exitCode: ownable2step.Errors.OnlyCallableByOwner,
+    })
+
+    expect(await baseTest.bind.mcms.getOracle()).toEqualAddress(ZERO_ADDRESS)
+  })
+
+  it('should allow oracle to submit an error report and expire root', async () => {
+    // Setup oracle role
+    const r = await baseTest.bind.mcms.sendInternal(
+      baseTest.acc.multisigOwner.getSender(),
+      toNano('1'),
+      mcms.builder.message.in.transferOracleRole.encode({
+        queryId: 1n,
+        newOracle: acc.oracle.address,
+      }),
+    )
+
+    expect(await baseTest.bind.mcms.getOracle()).toEqualAddress(acc.oracle.address)
+
+    // Execute first operation
+    const proof1 = baseTest.getProofForOp(0)
+
+    const execBody = mcms.builder.message.in.execute.encode({
+      queryId: 1n,
+      op: mcms.builder.data.op.encode(baseTest.testOps[0]),
+      proof: proof1,
+    })
+
+    const r1 = await baseTest.bind.mcms.sendInternal(
+      baseTest.acc.deployer.getSender(),
+      toNano('1'),
+      execBody,
+    )
+
+    expect(r1.transactions).toHaveTransaction({
+      from: baseTest.acc.deployer.address,
+      to: baseTest.bind.mcms.address,
+      success: true,
+    })
+
+    // Check that the op count was incremented
+    const opCount = await baseTest.bind.mcms.getOpCount()
+    expect(opCount).toEqual(baseTest.testOps[0].nonce + 1n)
+
+    // Submit an error report
+    const txHash = BigInt('0x' + r1.transactions[0].hash().toString('hex'))
+
+    const r2 = await baseTest.bind.mcms.sendInternal(
+      acc.oracle.getSender(),
+      toNano('1'),
+      mcms.builder.message.in.submitErrorReport.encode({
+        queryId: 1n,
+        op: mcms.builder.data.op.encode(baseTest.testOps[0]),
+        proof: proof1,
+        opTxHash: txHash,
+        errorTxHash: txHash,
+        errorCode: 1337,
+      }),
+    )
+
+    expect(r2.transactions).toHaveTransaction({
+      from: acc.oracle.address,
+      to: baseTest.bind.mcms.address,
+      success: true,
+    })
+
+    // Try to re-execute the same op - should fail with WrongNonce
+    const r3 = await baseTest.bind.mcms.sendInternal(
+      baseTest.acc.deployer.getSender(),
+      toNano('1'),
+      execBody,
+    )
+
+    expect(r3.transactions).toHaveTransaction({
+      from: baseTest.acc.deployer.address,
+      to: baseTest.bind.mcms.address,
+      success: false,
+      exitCode: mcms.Error.ROOT_EXPIRED,
+    })
+  })
+
+  it('should allow setRoot (new) after an error report was submitted', async () => {})
+
+  it('should fail to submit error report if not oracle', async () => {})
+
+  it('should fail to submit error report if op not part of the current root', async () => {})
+})

--- a/contracts/tests/mcms/ManyChainMultiSigExecuteErrorOracle.spec.ts
+++ b/contracts/tests/mcms/ManyChainMultiSigExecuteErrorOracle.spec.ts
@@ -227,7 +227,59 @@ describe('MCMS - ManyChainMultiSigExecuteErrorOracleTest', () => {
     })
   })
 
-  it('should fail to submit error report if not oracle', async () => {})
+  it('should fail to submit error report if not oracle', async () => {
+    await _setupOracleRole()
 
-  it('should fail to submit error report if op not part of the current root', async () => {})
+    // Submit an error report
+    const proof = baseTest.getProofForOp(0)
+    const txHash = 13n
+
+    const r = await baseTest.bind.mcms.sendInternal(
+      baseTest.acc.multisigOwner.getSender(), // not an oracle
+      toNano('1'),
+      mcms.builder.message.in.submitErrorReport.encode({
+        queryId: 1n,
+        op: mcms.builder.data.op.encode(baseTest.testOps[0]),
+        proof,
+        opTxHash: txHash,
+        errorTxHash: txHash,
+        errorCode: 1337,
+      }),
+    )
+
+    expect(r.transactions).toHaveTransaction({
+      from: baseTest.acc.multisigOwner.address,
+      to: baseTest.bind.mcms.address,
+      success: false,
+      exitCode: mcms.Error.ERROR_UNAUTHORIZED_ORACLE,
+    })
+  })
+
+  it('should fail to submit error report if op not part of the current root', async () => {
+    await _setupOracleRole()
+
+    // Submit an error report
+    const invalidProof = [0n, 1n, 2n, 3n]
+    const txHash = 13n
+
+    const r = await baseTest.bind.mcms.sendInternal(
+      acc.oracle.getSender(),
+      toNano('1'),
+      mcms.builder.message.in.submitErrorReport.encode({
+        queryId: 1n,
+        op: mcms.builder.data.op.encode(baseTest.testOps[0]),
+        proof: invalidProof,
+        opTxHash: txHash,
+        errorTxHash: txHash,
+        errorCode: 1337,
+      }),
+    )
+
+    expect(r.transactions).toHaveTransaction({
+      from: acc.oracle.address,
+      to: baseTest.bind.mcms.address,
+      success: false,
+      exitCode: mcms.Error.PROOF_CANNOT_BE_VERIFIED,
+    })
+  })
 })

--- a/contracts/tests/mcms/ManyChainMultiSigSetRoot.spec.ts
+++ b/contracts/tests/mcms/ManyChainMultiSigSetRoot.spec.ts
@@ -158,14 +158,9 @@ describe('MCMS - ManyChainMultiSigSetRootTest', () => {
     })
 
     it('should revert on incorrect postOpCount', async () => {
-      // Recreate test operations (skip reverting op for this test)
-      const includeRevertingOp = false
-      baseTest.testOps = baseTest.createTestOps(
-        MCMSBaseSetRootAndExecuteTestSetup.OPS_NUM,
-        includeRevertingOp,
-      )
+      await baseTest.recreateTestOpsNoRevertingOp()
 
-      await baseTest.setInitialRoot()
+      // await baseTest.setInitialRoot()
       await baseTest.bind.mcms.sendInternal(
         baseTest.acc.deployer.getSender(),
         toNano('10'),
@@ -433,20 +428,7 @@ describe('MCMS - ManyChainMultiSigSetRootTest', () => {
     })
 
     it('should successfully set root after clearing', async () => {
-      // Recreate test operations (skip reverting op for this test)
-      // Notice: needs setting new root with new metadata
-      const includeRevertingOp = false
-      baseTest.testOps = baseTest.createTestOps(
-        MCMSBaseSetRootAndExecuteTestSetup.OPS_NUM,
-        includeRevertingOp,
-      )
-      await baseTest.setInitialRoot(
-        baseTest.createTestRootMetadata(
-          0n,
-          BigInt(MCMSBaseSetRootAndExecuteTestSetup.OPS_NUM),
-          true, // override root
-        ),
-      )
+      await baseTest.recreateTestOpsNoRevertingOp()
 
       // Execute all ops except one
       const targetOpCount = baseTest.initialTestRootMetadata.postOpCount - 1n
@@ -600,20 +582,7 @@ describe('MCMS - ManyChainMultiSigSetRootTest', () => {
     })
 
     it('should succeed when no override after everything executed', async () => {
-      // Recreate test operations (skip reverting op for this test)
-      // Notice: needs setting new root with new metadata
-      const includeRevertingOp = false
-      baseTest.testOps = baseTest.createTestOps(
-        MCMSBaseSetRootAndExecuteTestSetup.OPS_NUM,
-        includeRevertingOp,
-      )
-      await baseTest.setInitialRoot(
-        baseTest.createTestRootMetadata(
-          0n,
-          BigInt(MCMSBaseSetRootAndExecuteTestSetup.OPS_NUM),
-          true, // override root
-        ),
-      )
+      await baseTest.recreateTestOpsNoRevertingOp()
 
       const rootMetadata = await baseTest.bind.mcms.getRootMetadata()
       expect(rootMetadata.postOpCount).toBeGreaterThan(0n)

--- a/contracts/tests/mcms/ManyChainMultiSigSetRoot.spec.ts
+++ b/contracts/tests/mcms/ManyChainMultiSigSetRoot.spec.ts
@@ -39,6 +39,7 @@ describe('MCMS - ManyChainMultiSigSetRootTest', () => {
         BigInt(MCMSBaseSetRootAndExecuteTestSetup.TEST_VALID_UNTIL),
         corruptedRootMetadata,
         baseTest.testOps,
+        MCMSBaseSetRootAndExecuteTestSetup.OP_FINALIZATION_TIMEOUT_ZERO,
       )
       const setRootBody = mcms.builder.message.in.setRoot.encode(setRoot)
 
@@ -70,6 +71,7 @@ describe('MCMS - ManyChainMultiSigSetRootTest', () => {
         BigInt(MCMSBaseSetRootAndExecuteTestSetup.TEST_VALID_UNTIL),
         corruptedRootMetadata,
         baseTest.testOps,
+        MCMSBaseSetRootAndExecuteTestSetup.OP_FINALIZATION_TIMEOUT_ZERO,
       )
       const setRootBody = mcms.builder.message.in.setRoot.encode(setRoot)
 
@@ -102,6 +104,7 @@ describe('MCMS - ManyChainMultiSigSetRootTest', () => {
         BigInt(MCMSBaseSetRootAndExecuteTestSetup.TEST_VALID_UNTIL),
         corruptedRootMetadata,
         baseTest.testOps,
+        MCMSBaseSetRootAndExecuteTestSetup.OP_FINALIZATION_TIMEOUT_ZERO,
       )
       const setRootBody = mcms.builder.message.in.setRoot.encode(setRoot)
 
@@ -136,6 +139,7 @@ describe('MCMS - ManyChainMultiSigSetRootTest', () => {
         BigInt(MCMSBaseSetRootAndExecuteTestSetup.TEST_VALID_UNTIL),
         corruptedRootMetadata,
         baseTest.testOps,
+        MCMSBaseSetRootAndExecuteTestSetup.OP_FINALIZATION_TIMEOUT_ZERO,
       )
       const setRootBody = mcms.builder.message.in.setRoot.encode(setRoot)
 
@@ -154,6 +158,13 @@ describe('MCMS - ManyChainMultiSigSetRootTest', () => {
     })
 
     it('should revert on incorrect postOpCount', async () => {
+      // Recreate test operations (skip reverting op for this test)
+      const includeRevertingOp = false
+      baseTest.testOps = baseTest.createTestOps(
+        MCMSBaseSetRootAndExecuteTestSetup.OPS_NUM,
+        includeRevertingOp,
+      )
+
       await baseTest.setInitialRoot()
       await baseTest.bind.mcms.sendInternal(
         baseTest.acc.deployer.getSender(),
@@ -177,6 +188,7 @@ describe('MCMS - ManyChainMultiSigSetRootTest', () => {
         BigInt(MCMSBaseSetRootAndExecuteTestSetup.TEST_VALID_UNTIL),
         corruptedRootMetadata,
         baseTest.testOps,
+        MCMSBaseSetRootAndExecuteTestSetup.OP_FINALIZATION_TIMEOUT_ZERO,
       )
       const setRootBody = mcms.builder.message.in.setRoot.encode(setRoot)
 
@@ -208,6 +220,7 @@ describe('MCMS - ManyChainMultiSigSetRootTest', () => {
         BigInt(MCMSBaseSetRootAndExecuteTestSetup.TEST_VALID_UNTIL),
         baseTest.initialTestRootMetadata,
         baseTest.testOps,
+        MCMSBaseSetRootAndExecuteTestSetup.OP_FINALIZATION_TIMEOUT_ZERO,
       )
       const setRootBody = mcms.builder.message.in.setRoot.encode(setRoot)
 
@@ -241,6 +254,7 @@ describe('MCMS - ManyChainMultiSigSetRootTest', () => {
           BigInt(MCMSBaseSetRootAndExecuteTestSetup.TEST_VALID_UNTIL),
           rootMetadata,
           baseTest.testOps,
+          MCMSBaseSetRootAndExecuteTestSetup.OP_FINALIZATION_TIMEOUT_ZERO,
         )
         const setRootBody = mcms.builder.message.in.setRoot.encode(setRoot)
 
@@ -268,6 +282,7 @@ describe('MCMS - ManyChainMultiSigSetRootTest', () => {
           BigInt(MCMSBaseSetRootAndExecuteTestSetup.TEST_VALID_UNTIL),
           rootMetadata,
           baseTest.testOps,
+          MCMSBaseSetRootAndExecuteTestSetup.OP_FINALIZATION_TIMEOUT_ZERO,
         )
         const setRootBody = mcms.builder.message.in.setRoot.encode(setRoot)
 
@@ -295,6 +310,7 @@ describe('MCMS - ManyChainMultiSigSetRootTest', () => {
         BigInt(MCMSBaseSetRootAndExecuteTestSetup.TEST_VALID_UNTIL + 1),
         rootMetadata,
         baseTest.testOps,
+        MCMSBaseSetRootAndExecuteTestSetup.OP_FINALIZATION_TIMEOUT_ZERO,
       )
       const setRootBody = mcms.builder.message.in.setRoot.encode(setRoot)
 
@@ -345,6 +361,7 @@ describe('MCMS - ManyChainMultiSigSetRootTest', () => {
         BigInt(MCMSBaseSetRootAndExecuteTestSetup.TEST_VALID_UNTIL),
         baseTest.initialTestRootMetadata,
         baseTest.testOps,
+        MCMSBaseSetRootAndExecuteTestSetup.OP_FINALIZATION_TIMEOUT_ZERO,
       )
       const setRootBody = mcms.builder.message.in.setRoot.encode(setRoot)
 
@@ -394,6 +411,7 @@ describe('MCMS - ManyChainMultiSigSetRootTest', () => {
         BigInt(MCMSBaseSetRootAndExecuteTestSetup.TEST_VALID_UNTIL),
         overrideMetadata,
         baseTest.testOps,
+        MCMSBaseSetRootAndExecuteTestSetup.OP_FINALIZATION_TIMEOUT_ZERO,
       )
       const setRootBody = mcms.builder.message.in.setRoot.encode(setRoot)
 
@@ -415,6 +433,21 @@ describe('MCMS - ManyChainMultiSigSetRootTest', () => {
     })
 
     it('should successfully set root after clearing', async () => {
+      // Recreate test operations (skip reverting op for this test)
+      // Notice: needs setting new root with new metadata
+      const includeRevertingOp = false
+      baseTest.testOps = baseTest.createTestOps(
+        MCMSBaseSetRootAndExecuteTestSetup.OPS_NUM,
+        includeRevertingOp,
+      )
+      await baseTest.setInitialRoot(
+        baseTest.createTestRootMetadata(
+          0n,
+          BigInt(MCMSBaseSetRootAndExecuteTestSetup.OPS_NUM),
+          true, // override root
+        ),
+      )
+
       // Execute all ops except one
       const targetOpCount = baseTest.initialTestRootMetadata.postOpCount - 1n
       await baseTest.executeOperationsUpTo(Number(targetOpCount))
@@ -457,6 +490,7 @@ describe('MCMS - ManyChainMultiSigSetRootTest', () => {
         BigInt(MCMSBaseSetRootAndExecuteTestSetup.TEST_VALID_UNTIL),
         newRootMetadata,
         baseTest.testOps,
+        MCMSBaseSetRootAndExecuteTestSetup.OP_FINALIZATION_TIMEOUT_ZERO,
       )
       const setRootBody = mcms.builder.message.in.setRoot.encode(setRoot)
 
@@ -487,6 +521,7 @@ describe('MCMS - ManyChainMultiSigSetRootTest', () => {
         BigInt(MCMSBaseSetRootAndExecuteTestSetup.TEST_VALID_UNTIL + 1),
         newRootMetadata,
         baseTest.testOps,
+        MCMSBaseSetRootAndExecuteTestSetup.OP_FINALIZATION_TIMEOUT_ZERO,
       ) // TODO: Original test doesn't add this 1, but this test fails with ERROR_SIGNED_HASH_ALREADY_SEEN if we don't. Thats probably a bug? Should the "override previous root" be used to calculate the hash? Or maybe it is a problem in the order of validations
       const setRootBody = mcms.builder.message.in.setRoot.encode(setRoot)
 
@@ -521,6 +556,7 @@ describe('MCMS - ManyChainMultiSigSetRootTest', () => {
           BigInt(MCMSBaseSetRootAndExecuteTestSetup.TEST_VALID_UNTIL),
           emptyRootMetadata,
           baseTest.testOps,
+          MCMSBaseSetRootAndExecuteTestSetup.OP_FINALIZATION_TIMEOUT_ZERO,
         )
         const setRootBody = mcms.builder.message.in.setRoot.encode(setRoot)
 
@@ -546,6 +582,7 @@ describe('MCMS - ManyChainMultiSigSetRootTest', () => {
         BigInt(MCMSBaseSetRootAndExecuteTestSetup.TEST_VALID_UNTIL),
         newRootMetadata,
         baseTest.testOps,
+        MCMSBaseSetRootAndExecuteTestSetup.OP_FINALIZATION_TIMEOUT_ZERO,
       )
       const setRootBody = mcms.builder.message.in.setRoot.encode(setRoot)
 
@@ -563,6 +600,21 @@ describe('MCMS - ManyChainMultiSigSetRootTest', () => {
     })
 
     it('should succeed when no override after everything executed', async () => {
+      // Recreate test operations (skip reverting op for this test)
+      // Notice: needs setting new root with new metadata
+      const includeRevertingOp = false
+      baseTest.testOps = baseTest.createTestOps(
+        MCMSBaseSetRootAndExecuteTestSetup.OPS_NUM,
+        includeRevertingOp,
+      )
+      await baseTest.setInitialRoot(
+        baseTest.createTestRootMetadata(
+          0n,
+          BigInt(MCMSBaseSetRootAndExecuteTestSetup.OPS_NUM),
+          true, // override root
+        ),
+      )
+
       const rootMetadata = await baseTest.bind.mcms.getRootMetadata()
       expect(rootMetadata.postOpCount).toBeGreaterThan(0n)
 
@@ -584,6 +636,7 @@ describe('MCMS - ManyChainMultiSigSetRootTest', () => {
         BigInt(MCMSBaseSetRootAndExecuteTestSetup.TEST_VALID_UNTIL),
         newRootMetadata,
         baseTest.testOps,
+        MCMSBaseSetRootAndExecuteTestSetup.OP_FINALIZATION_TIMEOUT_ZERO,
       )
       const setRootBody = mcms.builder.message.in.setRoot.encode(setRoot)
 
@@ -617,6 +670,7 @@ describe('MCMS - ManyChainMultiSigSetRootTest', () => {
         BigInt(MCMSBaseSetRootAndExecuteTestSetup.TEST_VALID_UNTIL),
         baseTest.initialTestRootMetadata,
         baseTest.testOps,
+        MCMSBaseSetRootAndExecuteTestSetup.OP_FINALIZATION_TIMEOUT_ZERO,
       )
       setRoot.metadata = corruptedMetadata
       const setRootBody = mcms.builder.message.in.setRoot.encode(setRoot)
@@ -648,6 +702,7 @@ describe('MCMS - ManyChainMultiSigSetRootTest', () => {
         BigInt(MCMSBaseSetRootAndExecuteTestSetup.TEST_VALID_UNTIL),
         baseTest.initialTestRootMetadata,
         baseTest.testOps,
+        MCMSBaseSetRootAndExecuteTestSetup.OP_FINALIZATION_TIMEOUT_ZERO,
       )
       setRoot.metadata = corruptedMetadata
       const setRootBody = mcms.builder.message.in.setRoot.encode(setRoot)
@@ -678,6 +733,7 @@ describe('MCMS - ManyChainMultiSigSetRootTest', () => {
         BigInt(MCMSBaseSetRootAndExecuteTestSetup.TEST_VALID_UNTIL),
         baseTest.initialTestRootMetadata,
         baseTest.testOps,
+        MCMSBaseSetRootAndExecuteTestSetup.OP_FINALIZATION_TIMEOUT_ZERO,
       )
       setRoot.metadata = corruptedMetadata
       const setRootBody = mcms.builder.message.in.setRoot.encode(setRoot)
@@ -708,6 +764,7 @@ describe('MCMS - ManyChainMultiSigSetRootTest', () => {
         BigInt(MCMSBaseSetRootAndExecuteTestSetup.TEST_VALID_UNTIL),
         baseTest.initialTestRootMetadata,
         baseTest.testOps,
+        MCMSBaseSetRootAndExecuteTestSetup.OP_FINALIZATION_TIMEOUT_ZERO,
       )
       setRoot.metadata = corruptedMetadata
       const setRootBody = mcms.builder.message.in.setRoot.encode(setRoot)
@@ -739,6 +796,7 @@ describe('MCMS - ManyChainMultiSigSetRootTest', () => {
         BigInt(MCMSBaseSetRootAndExecuteTestSetup.TEST_VALID_UNTIL),
         baseTest.initialTestRootMetadata,
         baseTest.testOps,
+        MCMSBaseSetRootAndExecuteTestSetup.OP_FINALIZATION_TIMEOUT_ZERO,
       )
       setRoot.metadata = corruptedMetadata
       const setRootBody = mcms.builder.message.in.setRoot.encode(setRoot)
@@ -829,6 +887,7 @@ describe('MCMS - ManyChainMultiSigSetRootTest', () => {
         BigInt(MCMSBaseSetRootAndExecuteTestSetup.TEST_VALID_UNTIL),
         baseTest.initialTestRootMetadata,
         baseTest.testOps,
+        MCMSBaseSetRootAndExecuteTestSetup.OP_FINALIZATION_TIMEOUT_ZERO,
       )
       const setRootBody = mcms.builder.message.in.setRoot.encode(setRoot)
       const result = await baseTest.bind.mcms.sendInternal(
@@ -850,6 +909,7 @@ describe('MCMS - ManyChainMultiSigSetRootTest', () => {
         BigInt(MCMSBaseSetRootAndExecuteTestSetup.TEST_VALID_UNTIL),
         baseTest.initialTestRootMetadata,
         baseTest.testOps,
+        MCMSBaseSetRootAndExecuteTestSetup.OP_FINALIZATION_TIMEOUT_ZERO,
       )
       const setRootBody = mcms.builder.message.in.setRoot.encode(setRoot)
       const result = await baseTest.bind.mcms.sendInternal(
@@ -877,6 +937,7 @@ describe('MCMS - ManyChainMultiSigSetRootTest', () => {
         BigInt(MCMSBaseSetRootAndExecuteTestSetup.TEST_VALID_UNTIL),
         baseTest.initialTestRootMetadata,
         baseTest.testOps,
+        MCMSBaseSetRootAndExecuteTestSetup.OP_FINALIZATION_TIMEOUT_ZERO,
       )
       const setRootBody = mcms.builder.message.in.setRoot.encode(setRoot)
       const result = await baseTest.bind.mcms.sendInternal(
@@ -899,12 +960,12 @@ describe('MCMS - ManyChainMultiSigSetRootTest', () => {
         sign: (data: Buffer<ArrayBufferLike>) => sign(data, s.keyPair.secretKey),
       }))
       signers[0] = signers[1] // Repeat the first signer
-
       const [setRoot, opProofs] = merkleProof.build(
         signers,
         BigInt(MCMSBaseSetRootAndExecuteTestSetup.TEST_VALID_UNTIL),
         baseTest.initialTestRootMetadata,
         baseTest.testOps,
+        MCMSBaseSetRootAndExecuteTestSetup.OP_FINALIZATION_TIMEOUT_ZERO,
       )
       const corruptOps = [...baseTest.testOps]
       corruptOps[0].data = beginCell().storeUint(0x2222222, 32).endCell()
@@ -913,6 +974,7 @@ describe('MCMS - ManyChainMultiSigSetRootTest', () => {
         BigInt(MCMSBaseSetRootAndExecuteTestSetup.TEST_VALID_UNTIL),
         baseTest.initialTestRootMetadata,
         corruptOps,
+        MCMSBaseSetRootAndExecuteTestSetup.OP_FINALIZATION_TIMEOUT_ZERO,
       )
       setRoot.root = corruptSetRoot.root
 
@@ -942,6 +1004,7 @@ describe('MCMS - ManyChainMultiSigSetRootTest', () => {
         BigInt(MCMSBaseSetRootAndExecuteTestSetup.TEST_VALID_UNTIL),
         baseTest.initialTestRootMetadata,
         baseTest.testOps,
+        MCMSBaseSetRootAndExecuteTestSetup.OP_FINALIZATION_TIMEOUT_ZERO,
       )
       setRoot.validUntil = BigInt(MCMSBaseSetRootAndExecuteTestSetup.TEST_VALID_UNTIL + 1)
 

--- a/contracts/tests/mcms/ManyChainMultiSigSubgroups.spec.ts
+++ b/contracts/tests/mcms/ManyChainMultiSigSubgroups.spec.ts
@@ -208,6 +208,7 @@ describe('MCMS - ManyChainMultiSigSubgroupsTest', () => {
       BigInt(MCMSBaseTestSetup.TEST_VALID_UNTIL),
       rootMetadata,
       testOps,
+      MCMSBaseTestSetup.OP_FINALIZATION_TIMEOUT_ZERO,
     )
 
     const insufficientSetRootBody = mcms.builder.message.in.setRoot.encode(insufficientSetRoot)
@@ -231,6 +232,7 @@ describe('MCMS - ManyChainMultiSigSubgroupsTest', () => {
       BigInt(MCMSBaseTestSetup.TEST_VALID_UNTIL),
       rootMetadata,
       testOps,
+      MCMSBaseTestSetup.OP_FINALIZATION_TIMEOUT_ZERO,
     )
   })
 
@@ -360,6 +362,7 @@ describe('MCMS - ManyChainMultiSigSubgroupsTest', () => {
           BigInt(MCMSBaseTestSetup.TEST_VALID_UNTIL),
           rootMetadata,
           testOps,
+          MCMSBaseTestSetup.OP_FINALIZATION_TIMEOUT_ZERO,
         )
 
         const reducedSetRootBody = mcms.builder.message.in.setRoot.encode(reducedSetRoot)
@@ -395,6 +398,7 @@ describe('MCMS - ManyChainMultiSigSubgroupsTest', () => {
       BigInt(MCMSBaseTestSetup.TEST_VALID_UNTIL),
       overrideMetadata,
       testOps,
+      MCMSBaseTestSetup.OP_FINALIZATION_TIMEOUT_ZERO,
     )
 
     const overrideSetRootBody = mcms.builder.message.in.setRoot.encode(overrideSetRoot)

--- a/contracts/wrappers/examples/Counter.ts
+++ b/contracts/wrappers/examples/Counter.ts
@@ -14,14 +14,14 @@ import { CellCodec } from '../utils'
 
 /// @dev Message to set the counter value.
 export type SetCount = {
-  // Query ID of the change owner request.
+  // Query ID of the change request.
   queryId: bigint
   newCount: number
 }
 
 /// Message to increase the counter value.
 export type IncreaseCount = {
-  // Query ID of the change owner request.
+  // Query ID of the change request.
   queryId: bigint
 }
 

--- a/contracts/wrappers/lib/access/AccessControl.ts
+++ b/contracts/wrappers/lib/access/AccessControl.ts
@@ -13,7 +13,7 @@ import { CellCodec } from '../../utils'
 
 // @dev Grants `role` to `account`.
 export type GrantRole = {
-  /// Query ID of the change owner request.
+  /// Query ID of the change request.
   queryId: bigint
 
   /// Role of the account.
@@ -24,7 +24,7 @@ export type GrantRole = {
 
 // @dev Revokes `role` from `account`.
 export type RevokeRole = {
-  /// Query ID of the change owner request.
+  /// Query ID of the change request.
   queryId: bigint
 
   /// Role of the account.
@@ -35,7 +35,7 @@ export type RevokeRole = {
 
 // @dev Renounces `role` from calling account.
 export type RenounceRole = {
-  /// Query ID of the change owner request.
+  /// Query ID of the change request.
   queryId: bigint
 
   /// Role of the account.

--- a/contracts/wrappers/libraries/access/Ownable2Step.ts
+++ b/contracts/wrappers/libraries/access/Ownable2Step.ts
@@ -19,7 +19,7 @@ export enum Errors {
 
 // @dev Message sent by the owner to transfer ownership of a contract.
 export type TransferOwnership = {
-  // Query ID of the change owner request.
+  // Query ID of the change request.
   queryId: bigint
   // New owner address.
   newOwner: Address
@@ -27,7 +27,7 @@ export type TransferOwnership = {
 
 /// Message sent by the pending owner to accept ownership of a contract.
 export type AcceptOwnership = {
-  // Query ID of the change owner request.
+  // Query ID of the change request.
   queryId: bigint
 }
 

--- a/contracts/wrappers/mcms/CallProxy.ts
+++ b/contracts/wrappers/mcms/CallProxy.ts
@@ -13,7 +13,7 @@ import { CellCodec } from '../utils'
 
 // @dev Top up contract with TON coins.
 export type TopUp = {
-  // Query ID of the change owner request.
+  // Query ID of the change request.
   queryId: bigint
 }
 

--- a/contracts/wrappers/mcms/MCMS.ts
+++ b/contracts/wrappers/mcms/MCMS.ts
@@ -92,8 +92,22 @@ export type SubmitErrorReport = {
   errorCode: number
 }
 
+/// Message sent by the owner to transfer the oracle role.
+export type TransferOracleRole = {
+  /// Query ID of the change request.
+  queryId: bigint
+  /// The address of the new oracle.
+  newOracle: Address
+}
+
 // @dev Union of all (input) messages.
-export type InMessage = TopUp | SetRoot | Execute | SetConfig | SubmitErrorReport
+export type InMessage =
+  | TopUp
+  | SetRoot
+  | Execute
+  | SetConfig
+  | SubmitErrorReport
+  | TransferOracleRole
 
 // MCMS contract storage
 export type ContractData = {
@@ -404,12 +418,14 @@ export const opcodes = {
     Execute: crc32('MCMS_Execute'),
     SetConfig: crc32('MCMS_SetConfig'),
     SubmitErrorReport: crc32('MCMS_SubmitErrorReport'),
+    TransferOracleRole: crc32('MCMS_TransferOracleRole'),
   },
   out: {
     NewRoot: crc32('MCMS_NewRoot'),
     ConfigSet: crc32('MCMS_ConfigSet'),
     OpExecuted: crc32('MCMS_OpExecuted'),
     ErrorReportedSubmitted: crc32('MCMS_ErrorReportSubmitted'),
+    OracleRoleTransferred: crc32('MCMS_OracleRoleTransferred'),
   },
 }
 
@@ -566,6 +582,23 @@ export const builder = {
             opTxHash: s.loadUintBig(256),
             errorTxHash: s.loadUintBig(256),
             errorCode: s.loadUint(32),
+          }
+        },
+      },
+      transferOracleRole: {
+        encode: (msg: TransferOracleRole): Cell => {
+          return beginCell()
+            .storeUint(opcodes.in.TransferOracleRole, 32)
+            .storeUint(msg.queryId, 64)
+            .storeAddress(msg.newOracle)
+            .endCell()
+        },
+        decode: (cell: Cell): TransferOracleRole => {
+          const s = cell.beginParse()
+          s.skip(32) // skip opcode
+          return {
+            queryId: s.loadUintBig(64),
+            newOracle: s.loadAddress(),
           }
         },
       },
@@ -766,43 +799,29 @@ export const builder = {
       },
       decode: (cell: Cell): ContractData => {
         const s = cell.beginParse()
-
-        const id = s.loadUint(32)
-        const ownable = {
-          owner: s.loadAddress(),
-          pendingOwner: s.loadAddress(),
-        }
-
-        const oracle = s.loadAddress()
-
-        const signers = loadDict(
-          Dictionary.loadDirect(
-            Dictionary.Keys.BigUint(256),
-            Dictionary.Values.Buffer(LEN_SIGNER_BYTES),
-            s.loadRef(),
-          ),
-        )
-
-        const _config = config.decode(s.loadRef())
-
-        const seenSignedHashes = loadDict(
-          Dictionary.loadDirect(
-            Dictionary.Keys.BigUint(256),
-            Dictionary.Values.Bool(),
-            s.loadRef(),
-          ),
-        )
-
-        const _rootInfo = rootInfo.decode(s.loadRef())
-
         return {
-          id,
-          ownable,
-          oracle,
-          signers,
-          config: _config,
-          seenSignedHashes,
-          rootInfo: _rootInfo,
+          id: s.loadUint(32),
+          ownable: {
+            owner: s.loadAddress(),
+            pendingOwner: s.loadAddress(),
+          },
+          oracle: s.loadAddress(),
+          signers: loadDict(
+            Dictionary.loadDirect(
+              Dictionary.Keys.BigUint(256),
+              Dictionary.Values.Buffer(LEN_SIGNER_BYTES),
+              s.loadRef(),
+            ),
+          ),
+          config: config.decode(s.loadRef()),
+          seenSignedHashes: loadDict(
+            Dictionary.loadDirect(
+              Dictionary.Keys.BigUint(256),
+              Dictionary.Values.Bool(),
+              s.loadRef(),
+            ),
+          ),
+          rootInfo: rootInfo.decode(s.loadRef()),
         }
       },
     }

--- a/contracts/wrappers/mcms/MCMS.ts
+++ b/contracts/wrappers/mcms/MCMS.ts
@@ -296,7 +296,7 @@ export type ExpiringRootAndOpCount = {
 /// This is TON-specific additional data required to support reliable execution in the async environment.
 export type OpPendingInfo = {
   /// The time at which the root becomes valid [executionTime(opCount - 1) + opFinalizationTimeout].
-  /// At this time the previous executed operation is considered optimistically final and succesfull,
+  /// At this time the previous executed operation is considered optimistically final and successful,
   /// meaning no bounce was received and we can continue executing.
   validAfter: bigint // uint32
   /// The timeout required to finalize the currently executing op

--- a/contracts/wrappers/mcms/MCMS.ts
+++ b/contracts/wrappers/mcms/MCMS.ts
@@ -956,6 +956,17 @@ export class ContractClient implements Contract {
     return p.get('getRoot', []).then((r) => [r.stack.readBigNumber(), r.stack.readBigNumber()])
   }
 
+  async getOpPendingInfo(p: ContractProvider): Promise<OpPendingInfo> {
+    return p.get('getOpPendingInfo', []).then((r) => {
+      return {
+        validAfter: r.stack.readBigNumber(),
+        opFinalizationTimeout: r.stack.readBigNumber(),
+        opPendingReceiver: r.stack.readAddressOpt() || ZERO_ADDRESS,
+        opPendingBodyTruncated: r.stack.readBigNumber(),
+      }
+    })
+  }
+
   async getRootMetadata(p: ContractProvider): Promise<RootMetadata> {
     return p.get('getRootMetadata', []).then((r) => {
       return {
@@ -968,14 +979,7 @@ export class ContractClient implements Contract {
     })
   }
 
-  async getOpPendingInfo(p: ContractProvider): Promise<OpPendingInfo> {
-    return p.get('getOpPendingInfo', []).then((r) => {
-      return {
-        validAfter: r.stack.readBigNumber(),
-        opFinalizationTimeout: r.stack.readBigNumber(),
-        opPendingReceiver: r.stack.readAddressOpt() || ZERO_ADDRESS,
-        opPendingBodyTruncated: r.stack.readBigNumber(),
-      }
-    })
+  async getOracle(p: ContractProvider): Promise<Address> {
+    return p.get('getOracle', []).then((r) => r.stack.readAddress())
   }
 }

--- a/contracts/wrappers/mcms/MCMS.ts
+++ b/contracts/wrappers/mcms/MCMS.ts
@@ -887,4 +887,15 @@ export class ContractClient implements Contract {
       }
     })
   }
+
+  async getOpPendingInfo(p: ContractProvider): Promise<OpPendingInfo> {
+    return p.get('getOpPendingInfo', []).then((r) => {
+      return {
+        validAfter: r.stack.readBigNumber(),
+        opFinalizationTimeout: r.stack.readBigNumber(),
+        opPendingReceiver: r.stack.readAddressOpt() || ZERO_ADDRESS,
+        opPendingBodyVal: r.stack.readBigNumber(),
+      }
+    })
+  }
 }

--- a/contracts/wrappers/mcms/MCMS.ts
+++ b/contracts/wrappers/mcms/MCMS.ts
@@ -184,6 +184,9 @@ export enum Error {
 
   /// @notice Thrown when the root has not been finalized yet (can't execute next op before finalization).
   ERROR_ROOT_NOT_FINALIZED = 122,
+
+  /// @notice Thrown when the provided op.value is insufficient (min required value not met).
+  ERROR_INSUFFICIENT_VALUE = 123,
 }
 
 // --- Data structures ---

--- a/contracts/wrappers/mcms/MCMS.ts
+++ b/contracts/wrappers/mcms/MCMS.ts
@@ -36,6 +36,8 @@ export type SetRoot = {
   metadataProof: Cell // vec<uint256>
   // The ECDSA signatures on (root, validUntil).
   signatures: Cell // vec<Signature>
+  /// The timeout required to finalize the currently executing op
+  opFinalizationTimeout: bigint // uint32
 }
 
 // @dev Executes an operation authenticated by the Merkle tree.
@@ -83,10 +85,8 @@ export type ContractData = {
 
   /// Remember signedHashes that this contract has seen. Each signedHash can only be set once.
   seenSignedHashes: Map<bigint, boolean> // map<uint256, bool>
-  /// The current expiring root and the number of ops in it.
-  expiringRootAndOpCount: ExpiringRootAndOpCount
-  /// The current metadata about the root.
-  rootMetadata: RootMetadata
+  /// The current RootMetadata and ExpiringRootAndOpCount wrapped in a cell bc size limits.
+  rootInfo: RootInfo
 }
 
 // --- Constants ---
@@ -181,6 +181,9 @@ export enum Error {
 
   /// @notice Thrown when attempt to set the same (root, validUntil) in setRoot().
   SIGNED_HASH_ALREADY_SEEN = 121,
+
+  /// @notice Thrown when the root has not been finalized yet (can't execute next op before finalization).
+  ERROR_ROOT_NOT_FINALIZED = 122,
 }
 
 // --- Data structures ---
@@ -261,6 +264,14 @@ export type Config = {
   groupParents: Map<number, number> // map<uint8, uint8> (indexed, iterable backwards)
 }
 
+/// Information about the current root, extracted into a separate struct (wrapped in a cell).
+export type RootInfo = {
+  /// The current expiring root and the number of ops in it.
+  expiringRootAndOpCount: ExpiringRootAndOpCount
+  /// The current metadata about the root.
+  rootMetadata: RootMetadata
+}
+
 /// MerkleRoots are a bit tricky since they reveal almost no information about the contents of
 /// the tree they authenticate. To mitigate this, we enforce that this contract can only execute
 /// ops from a single root at any given point in time. We further associate an expiry
@@ -277,9 +288,13 @@ export type ExpiringRootAndOpCount = {
   validUntil: bigint //uint32
   /// each ManyChainMultiSig instance has it own independent opCount.
   opCount: bigint // uint40
+  /// Information about the currently pending operation.
+  opPendingInfo: OpPendingInfo
+}
 
-  /// TON-specific additions below to support the async environment
-  ///
+/// Information about the currently pending operation.
+/// This is TON-specific additional data required to support reliable execution in the async environment.
+export type OpPendingInfo = {
   /// The time at which the root becomes valid [executionTime(opCount - 1) + opFinalizationTimeout].
   /// At this time the previous executed operation is considered optimistically final and succesfull,
   /// meaning no bounce was received and we can continue executing.
@@ -416,6 +431,7 @@ export const builder = {
             .storeBuilder(rootMetadata.encode(msg.metadata).asBuilder())
             .storeRef(msg.metadataProof)
             .storeRef(msg.signatures)
+            .storeUint(msg.opFinalizationTimeout, 32)
             .endCell()
         },
         decode: (cell: Cell): SetRoot => {
@@ -428,6 +444,7 @@ export const builder = {
             metadata: s.loadRef().beginParse() as unknown as RootMetadata, // TODO: decode metadata properly
             metadataProof: s.loadRef(),
             signatures: s.loadRef(),
+            opFinalizationTimeout: s.loadUintBig(32),
           }
         },
       },
@@ -539,16 +556,33 @@ export const builder = {
       },
     }
 
+    const opPendingInfo: CellCodec<OpPendingInfo> = {
+      encode: (data: OpPendingInfo): Cell => {
+        return beginCell()
+          .storeUint(data.validAfter, 32)
+          .storeUint(data.opFinalizationTimeout, 32)
+          .storeAddress(data.opPendingReceiver)
+          .storeUint(data.opPendingBodyVal, 256)
+          .endCell()
+      },
+      decode: (cell: Cell): OpPendingInfo => {
+        const s = cell.beginParse()
+        return {
+          validAfter: s.loadUintBig(32),
+          opFinalizationTimeout: s.loadUintBig(32),
+          opPendingReceiver: s.loadAddress(),
+          opPendingBodyVal: s.loadUintBig(256),
+        }
+      },
+    }
+
     const expiringRootAndOpCount: CellCodec<ExpiringRootAndOpCount> = {
       encode: (data: ExpiringRootAndOpCount): Cell => {
         return beginCell()
           .storeUint(data.root, 256)
           .storeUint(data.validUntil, 32)
           .storeUint(data.opCount, 40)
-          .storeUint(data.validAfter, 32)
-          .storeUint(data.opFinalizationTimeout, 32)
-          .storeAddress(data.opPendingReceiver)
-          .storeUint(data.opPendingBodyVal, 256)
+          .storeRef(opPendingInfo.encode(data.opPendingInfo))
           .endCell()
       },
       decode: (cell: Cell): ExpiringRootAndOpCount => {
@@ -557,13 +591,28 @@ export const builder = {
           root: s.loadUintBig(256),
           validUntil: s.loadUintBig(32),
           opCount: s.loadUintBig(40),
-          validAfter: s.loadUintBig(32),
-          opFinalizationTimeout: s.loadUintBig(32),
-          opPendingReceiver: s.loadAddress(),
-          opPendingBodyVal: s.loadUintBig(256),
+          opPendingInfo: opPendingInfo.decode(s.loadRef()),
         }
       },
     }
+
+    /// Information about the current root, extracted into a separate struct (wrapped in a cell).
+    const rootInfo: CellCodec<RootInfo> = {
+      encode: (data: RootInfo): Cell => {
+        return beginCell()
+          .storeBuilder(expiringRootAndOpCount.encode(data.expiringRootAndOpCount).asBuilder())
+          .storeBuilder(rootMetadata.encode(data.rootMetadata).asBuilder())
+          .endCell()
+      },
+      decode: (cell: Cell): RootInfo => {
+        const s = cell.beginParse()
+        return {
+          expiringRootAndOpCount: expiringRootAndOpCount.decode(s.asCell()),
+          rootMetadata: rootMetadata.decode(s.asCell()),
+        }
+      },
+    }
+
     // Creates a new `Signer` data cell
     const signer: CellCodec<Signer> = {
       encode: (signer: Signer): Cell => {
@@ -652,8 +701,7 @@ export const builder = {
             Dictionary.Keys.BigUint(256),
             Dictionary.Values.Bool(),
           )
-          .storeBuilder(expiringRootAndOpCount.encode(data.expiringRootAndOpCount).asBuilder())
-          .storeRef(rootMetadata.encode(data.rootMetadata))
+          .storeRef(rootInfo.encode(data.rootInfo))
           .endCell()
       },
       decode: (cell: Cell): ContractData => {
@@ -683,23 +731,7 @@ export const builder = {
           ),
         )
 
-        const expiringRootAndOpCount = {
-          root: s.loadUintBig(256),
-          opCount: s.loadUintBig(40),
-          validUntil: s.loadUintBig(32),
-          validAfter: s.loadUintBig(32),
-          opFinalizationTimeout: s.loadUintBig(32),
-          opPendingReceiver: s.loadAddress(),
-          opPendingBodyVal: s.loadUintBig(256),
-        }
-
-        const rootMetadata = {
-          chainId: s.loadIntBig(256),
-          multiSig: s.loadAddress(),
-          preOpCount: s.loadUintBig(40),
-          postOpCount: s.loadUintBig(40),
-          overridePreviousRoot: s.loadBoolean(),
-        }
+        const _rootInfo = rootInfo.decode(s.loadRef())
 
         return {
           id,
@@ -707,8 +739,7 @@ export const builder = {
           signers,
           config: _config,
           seenSignedHashes,
-          expiringRootAndOpCount,
-          rootMetadata,
+          rootInfo: _rootInfo,
         }
       },
     }
@@ -727,21 +758,25 @@ export const builder = {
           groupParents: new Map<number, number>(),
         },
         seenSignedHashes: new Map<bigint, boolean>(),
-        expiringRootAndOpCount: {
-          root: 0n, // no root
-          validUntil: 0n, // no validity
-          opCount: 0n, // no ops
-          validAfter: 0n, // no valid after
-          opFinalizationTimeout: 0n, // no op finalization timeout
-          opPendingReceiver: ZERO_ADDRESS, // no op pending receiver
-          opPendingBodyVal: 0n, // no op pending body
-        },
-        rootMetadata: {
-          chainId: 0n, // no chain ID
-          multiSig: ZERO_ADDRESS, // no multiSig
-          preOpCount: 0n, // no pre-op count
-          postOpCount: 0n, // no post-op count
-          overridePreviousRoot: false, // no override
+        rootInfo: {
+          expiringRootAndOpCount: {
+            root: 0n, // no root
+            validUntil: 0n, // no validity
+            opCount: 0n, // no ops
+            opPendingInfo: {
+              validAfter: 0n, // no valid after
+              opFinalizationTimeout: 0n, // no op finalization timeout
+              opPendingReceiver: ZERO_ADDRESS, // no op pending receiver
+              opPendingBodyVal: 0n, // no op pending body
+            },
+          },
+          rootMetadata: {
+            chainId: 0n, // no chain ID
+            multiSig: ZERO_ADDRESS, // no multiSig
+            preOpCount: 0n, // no pre-op count
+            postOpCount: 0n, // no post-op count
+            overridePreviousRoot: false, // no override
+          },
         },
       }
     }
@@ -749,6 +784,7 @@ export const builder = {
     return {
       config,
       rootMetadata,
+      opPendingInfo,
       expiringRootAndOpCount,
       op,
       signature,
@@ -775,11 +811,7 @@ export class ContractClient implements Contract {
   }
 
   async sendInternal(p: ContractProvider, via: Sender, value: bigint, body: Cell) {
-    await p.internal(via, {
-      value: value,
-      sendMode: SendMode.PAY_GAS_SEPARATELY,
-      body: body,
-    })
+    await p.internal(via, { value, sendMode: SendMode.PAY_GAS_SEPARATELY, body })
   }
 
   async sendTopUp(p: ContractProvider, via: Sender, value: bigint = 0n, body: TopUp) {

--- a/contracts/wrappers/mcms/MCMS.ts
+++ b/contracts/wrappers/mcms/MCMS.ts
@@ -68,8 +68,32 @@ export type SetConfig = {
   clearRoot: boolean
 }
 
+/// Submit an oracle error report, which marks the current root as invalid.
+///
+/// The error report is used for a category of errors which might occur during execution
+/// of an operation, but can't be caught on-chain (OOG errors, and downstream tx-trace errors).
+///
+/// @dev The error oracle can only report errors for the current non-expired root, to avoid reporting
+/// stale errors for operations that are no longer valid.
+export type SubmitErrorReport = {
+  /// Query ID of the change request.
+  queryId: bigint
+
+  /// The operation which produced the error.
+  op: Cell // Cell<Op>
+  /// The MerkleProof for the op's inclusion in the MerkleTree
+  proof: bigint[] // vec<uint256>,
+  /// The hash of the execute transaction.
+  opTxHash: bigint
+
+  /// The hash of the transaction which errored (part of the tx trace).
+  errorTxHash: bigint
+  /// The error code.
+  errorCode: number
+}
+
 // @dev Union of all (input) messages.
-export type InMessage = TopUp | SetRoot | Execute | SetConfig
+export type InMessage = TopUp | SetRoot | Execute | SetConfig | SubmitErrorReport
 
 // MCMS contract storage
 export type ContractData = {
@@ -78,6 +102,8 @@ export type ContractData = {
 
   /// Ownable trait data
   ownable: ownable2step.Data
+  /// Address of the error oracle account, which can submit error reports.
+  oracle: Address
   /// Map where entry exists if the public key is a signer
   signers: Map<bigint, Buffer> // map<uint256, Signer>
   /// The current configuration of the contract
@@ -109,84 +135,87 @@ export const NUM_GROUPS = 32
 export const MAX_NUM_SIGNERS = 200
 
 export enum Error {
-  /// @notice Thrown when number of signers is 0 or greater than MAX_NUM_SIGNERS.
+  /// Thrown when number of signers is 0 or greater than MAX_NUM_SIGNERS.
   OUT_OF_BOUNDS_NUM_SIGNERS = 100,
 
-  /// @notice Thrown when signerKeys and signerGroups have different lengths.
+  /// Thrown when signerKeys and signerGroups have different lengths.
   SIGNER_GROUPS_LENGTH_MISMATCH = 101,
 
-  /// @notice Thrown when number of some signer's group is greater than (NUM_GROUPS-1).
+  /// Thrown when number of some signer's group is greater than (NUM_GROUPS-1).
   OUT_OF_BOUNDS_GROUP = 102,
 
-  /// @notice Thrown when the group tree isn't well-formed.
+  /// Thrown when the group tree isn't well-formed.
   GROUP_TREE_NOT_WELL_FORMED = 103,
 
-  /// @notice Thrown when the quorum of some group is larger than the number of signers in it.
+  /// Thrown when the quorum of some group is larger than the number of signers in it.
   OUT_OF_BOUNDS_GROUP_QUORUM = 104,
 
-  /// @notice Thrown when a disabled group contains a signer.
+  /// Thrown when a disabled group contains a signer.
   SIGNER_IN_DISABLED_GROUP = 105,
 
-  /// @notice Thrown when the signers' public keys are not a strictly increasing monotone sequence.
+  /// Thrown when the signers' public keys are not a strictly increasing monotone sequence.
   /// Prevents signers from including more than one signature.
   SIGNERS_KEYS_MUST_BE_STRICTLY_INCREASING = 106,
 
-  /// @notice Thrown when the signature corresponds to invalid signer.
+  /// Thrown when the signature corresponds to invalid signer.
   INVALID_SIGNER = 107,
 
-  /// @notice Thrown when there is no sufficient set of valid signatures provided to make the
+  /// Thrown when there is no sufficient set of valid signatures provided to make the
   /// root group successful.
   INSUFFICIENT_SIGNERS = 108,
 
-  /// @notice Thrown when attempt to set metadata or execute op for another chain.
+  /// Thrown when attempt to set metadata or execute op for another chain.
   WRONG_CHAIN_ID = 109,
 
-  /// @notice Thrown when the multiSig address in metadata or op is
+  /// Thrown when the multiSig address in metadata or op is
   /// incompatible with the address of this contract.
   WRONG_MULTI_SIG = 110,
 
-  /// @notice Thrown when the preOpCount <= postOpCount invariant is violated.
+  /// Thrown when the preOpCount <= postOpCount invariant is violated.
   WRONG_POST_OP_COUNT = 111,
 
-  /// @notice Thrown when attempting to set a new root while there are still pending ops
+  /// Thrown when attempting to set a new root while there are still pending ops
   /// from the previous root without explicitly overriding it.
   PENDING_OPS = 112,
 
-  /// @notice Thrown when preOpCount in metadata is incompatible with the current opCount.
+  /// Thrown when preOpCount in metadata is incompatible with the current opCount.
   WRONG_PRE_OP_COUNT = 113,
 
-  /// @notice Thrown when the provided merkle proof cannot be verified.
+  /// Thrown when the provided merkle proof cannot be verified.
   PROOF_CANNOT_BE_VERIFIED = 114,
 
-  /// @notice Thrown when attempt to execute an op after
+  /// Thrown when attempt to execute an op after
   /// s_expiringRootAndOpCount.validUntil has passed.
   ROOT_EXPIRED = 115,
 
-  /// @notice Thrown when attempt to bypass the enforced ops' order in the merkle tree or
+  /// Thrown when attempt to bypass the enforced ops' order in the merkle tree or
   /// re-execute an op.
   WRONG_NONCE = 116,
 
-  /// @notice Thrown when attempting to execute an op even though opCount equals
+  /// Thrown when attempting to execute an op even though opCount equals
   /// metadata.postOpCount.
   POST_OP_COUNT_REACHED = 117,
 
-  /// @notice Thrown when the underlying call in _execute() reverts.
+  /// Thrown when the underlying call in _execute() reverts.
   CALL_REVERTED = 118,
 
-  /// @notice Thrown when attempt to set past validUntil for the root.
+  /// Thrown when attempt to set past validUntil for the root.
   VALID_UNTIL_HAS_ALREADY_PASSED = 119,
 
-  /// @notice Thrown when setRoot() is called before setting a config.
+  /// Thrown when setRoot() is called before setting a config.
   MISSING_CONFIG = 120,
 
-  /// @notice Thrown when attempt to set the same (root, validUntil) in setRoot().
+  /// Thrown when attempt to set the same (root, validUntil) in setRoot().
   SIGNED_HASH_ALREADY_SEEN = 121,
 
-  /// @notice Thrown when the root has not been finalized yet (can't execute next op before finalization).
+  /// Thrown when the root has not been finalized yet (can't execute next op before finalization).
   ERROR_ROOT_NOT_FINALIZED = 122,
 
-  /// @notice Thrown when the provided op.value is insufficient (min required value not met).
+  /// Thrown when the provided op.value is insufficient (min required value not met).
   ERROR_INSUFFICIENT_VALUE = 123,
+
+  /// Thrown when the error report sender is not the authorized oracle.
+  ERROR_UNAUTHORIZED_ORACLE = 124,
 }
 
 // --- Data structures ---
@@ -311,7 +340,7 @@ export type OpPendingInfo = {
   opPendingBodyTruncated: bigint // uint256
 }
 
-/// @notice Each root also authenticates metadata about itself (stored as one of the leaves)
+/// Each root also authenticates metadata about itself (stored as one of the leaves)
 /// which must be revealed when the root is set.
 ///
 /// @dev We need to be careful that abi.encode(MANY_CHAIN_MULTI_SIG_DOMAIN_SEPARATOR_METADATA, RootMetadata)
@@ -348,7 +377,7 @@ export type Signature = {
   signer: bigint // uint256
 }
 
-/// @notice an op to be executed by the ManyChainMultiSig contract
+/// An op to be executed by the ManyChainMultiSig contract
 ///
 /// @dev We need to be careful that abi.encode(LEAF_OP_DOMAIN_SEPARATOR, RootMetadata)
 /// is greater than 64 bytes to prevent collisions with internal nodes in the Merkle tree. See
@@ -512,6 +541,31 @@ export const builder = {
               ),
             ),
             clearRoot: s.loadBoolean(),
+          }
+        },
+      },
+      submitErrorReport: {
+        encode: (msg: SubmitErrorReport): Cell => {
+          return beginCell()
+            .storeUint(opcodes.in.SubmitErrorReport, 32)
+            .storeUint(msg.queryId, 64)
+            .storeRef(msg.op)
+            .storeRef(asSnakeData<bigint>(msg.proof, (v) => beginCell().storeUint(v, 256)))
+            .storeUint(msg.opTxHash, 256)
+            .storeUint(msg.errorTxHash, 256)
+            .storeUint(msg.errorCode, 32)
+            .endCell()
+        },
+        decode: (cell: Cell): SubmitErrorReport => {
+          const s = cell.beginParse()
+          s.skip(32) // skip opcode
+          return {
+            queryId: s.loadUintBig(64),
+            op: s.loadRef(),
+            proof: fromSnakeData(s.loadRef(), (a) => a.loadUintBig(256)),
+            opTxHash: s.loadUintBig(256),
+            errorTxHash: s.loadUintBig(256),
+            errorCode: s.loadUint(32),
           }
         },
       },
@@ -691,6 +745,7 @@ export const builder = {
           .storeBuilder(
             beginCell().storeAddress(data.ownable.owner).storeMaybeBuilder(_pendingOwnerMaybe),
           )
+          .storeAddress(data.oracle)
           .storeDict(
             loadMap(
               Dictionary.Keys.BigUint(256),
@@ -718,6 +773,8 @@ export const builder = {
           pendingOwner: s.loadAddress(),
         }
 
+        const oracle = s.loadAddress()
+
         const signers = loadDict(
           Dictionary.loadDirect(
             Dictionary.Keys.BigUint(256),
@@ -741,6 +798,7 @@ export const builder = {
         return {
           id,
           ownable,
+          oracle,
           signers,
           config: _config,
           seenSignedHashes,
@@ -756,6 +814,7 @@ export const builder = {
           owner,
           pendingOwner: null, // no pending owner
         },
+        oracle: ZERO_ADDRESS,
         signers: new Map<bigint, Buffer>(),
         config: {
           signers: new Map<number, Buffer>(),

--- a/contracts/wrappers/mcms/MCMS.ts
+++ b/contracts/wrappers/mcms/MCMS.ts
@@ -17,13 +17,13 @@ import { loadDict, loadMap } from '../../src/utils/dict'
 
 // @dev Top up contract with TON coins.
 export type TopUp = {
-  // Query ID of the change owner request.
+  // Query ID of the change request.
   queryId: bigint
 }
 
 // @dev Sets a new expiring root.
 export type SetRoot = {
-  // Query ID of the change owner request.
+  // Query ID of the change request.
   queryId: bigint
 
   // The new expiring root.
@@ -53,7 +53,7 @@ export type Execute = {
 
 // @dev Sets the configuration for the contract.
 export type SetConfig = {
-  // Query ID of the change owner request.
+  // Query ID of the change request.
   queryId: bigint
 
   // List of signer public keys.
@@ -308,7 +308,7 @@ export type OpPendingInfo = {
   opPendingReceiver: Address
   /// The truncated body of the pending operation (256 bits from the original message),
   /// stored as the next expected potential bounce, and verified in onBounceMessage handler.
-  opPendingBodyVal: bigint // uint256
+  opPendingBodyTruncated: bigint // uint256
 }
 
 /// @notice Each root also authenticates metadata about itself (stored as one of the leaves)
@@ -374,11 +374,13 @@ export const opcodes = {
     SetRoot: crc32('MCMS_SetRoot'),
     Execute: crc32('MCMS_Execute'),
     SetConfig: crc32('MCMS_SetConfig'),
+    SubmitErrorReport: crc32('MCMS_SubmitErrorReport'),
   },
   out: {
     NewRoot: crc32('MCMS_NewRoot'),
     ConfigSet: crc32('MCMS_ConfigSet'),
     OpExecuted: crc32('MCMS_OpExecuted'),
+    ErrorReportedSubmitted: crc32('MCMS_ErrorReportSubmitted'),
   },
 }
 
@@ -565,7 +567,7 @@ export const builder = {
           .storeUint(data.validAfter, 32)
           .storeUint(data.opFinalizationTimeout, 32)
           .storeAddress(data.opPendingReceiver)
-          .storeUint(data.opPendingBodyVal, 256)
+          .storeUint(data.opPendingBodyTruncated, 256)
           .endCell()
       },
       decode: (cell: Cell): OpPendingInfo => {
@@ -574,7 +576,7 @@ export const builder = {
           validAfter: s.loadUintBig(32),
           opFinalizationTimeout: s.loadUintBig(32),
           opPendingReceiver: s.loadAddress(),
-          opPendingBodyVal: s.loadUintBig(256),
+          opPendingBodyTruncated: s.loadUintBig(256),
         }
       },
     }
@@ -770,7 +772,7 @@ export const builder = {
               validAfter: 0n, // no valid after
               opFinalizationTimeout: 0n, // no op finalization timeout
               opPendingReceiver: ZERO_ADDRESS, // no op pending receiver
-              opPendingBodyVal: 0n, // no op pending body
+              opPendingBodyTruncated: 0n, // no op pending body
             },
           },
           rootMetadata: {
@@ -894,7 +896,7 @@ export class ContractClient implements Contract {
         validAfter: r.stack.readBigNumber(),
         opFinalizationTimeout: r.stack.readBigNumber(),
         opPendingReceiver: r.stack.readAddressOpt() || ZERO_ADDRESS,
-        opPendingBodyVal: r.stack.readBigNumber(),
+        opPendingBodyTruncated: r.stack.readBigNumber(),
       }
     })
   }

--- a/contracts/wrappers/mcms/MCMS.ts
+++ b/contracts/wrappers/mcms/MCMS.ts
@@ -6,7 +6,6 @@ import {
   contractAddress,
   ContractProvider,
   Dictionary,
-  DictionaryKeyTypes,
   Sender,
   SendMode,
 } from '@ton/core'
@@ -278,6 +277,20 @@ export type ExpiringRootAndOpCount = {
   validUntil: bigint //uint32
   /// each ManyChainMultiSig instance has it own independent opCount.
   opCount: bigint // uint40
+
+  /// TON-specific additions below to support the async environment
+  ///
+  /// The time at which the root becomes valid [executionTime(opCount - 1) + opFinalizationTimeout].
+  /// At this time the previous executed operation is considered optimistically final and succesfull,
+  /// meaning no bounce was received and we can continue executing.
+  validAfter: bigint // uint32
+  /// The timeout required to finalize the currently executing op
+  opFinalizationTimeout: bigint // uint32
+  /// The address that the (pending) operation was sent to (and could bounce from).
+  opPendingReceiver: Address
+  /// The truncated body of the pending operation (256 bits from the original message),
+  /// stored as the next expected potential bounce, and verified in onBounceMessage handler.
+  opPendingBodyVal: bigint // uint256
 }
 
 /// @notice Each root also authenticates metadata about itself (stored as one of the leaves)
@@ -532,6 +545,10 @@ export const builder = {
           .storeUint(data.root, 256)
           .storeUint(data.validUntil, 32)
           .storeUint(data.opCount, 40)
+          .storeUint(data.validAfter, 32)
+          .storeUint(data.opFinalizationTimeout, 32)
+          .storeAddress(data.opPendingReceiver)
+          .storeUint(data.opPendingBodyVal, 256)
           .endCell()
       },
       decode: (cell: Cell): ExpiringRootAndOpCount => {
@@ -540,6 +557,10 @@ export const builder = {
           root: s.loadUintBig(256),
           validUntil: s.loadUintBig(32),
           opCount: s.loadUintBig(40),
+          validAfter: s.loadUintBig(32),
+          opFinalizationTimeout: s.loadUintBig(32),
+          opPendingReceiver: s.loadAddress(),
+          opPendingBodyVal: s.loadUintBig(256),
         }
       },
     }
@@ -666,6 +687,10 @@ export const builder = {
           root: s.loadUintBig(256),
           opCount: s.loadUintBig(40),
           validUntil: s.loadUintBig(32),
+          validAfter: s.loadUintBig(32),
+          opFinalizationTimeout: s.loadUintBig(32),
+          opPendingReceiver: s.loadAddress(),
+          opPendingBodyVal: s.loadUintBig(256),
         }
 
         const rootMetadata = {
@@ -706,6 +731,10 @@ export const builder = {
           root: 0n, // no root
           validUntil: 0n, // no validity
           opCount: 0n, // no ops
+          validAfter: 0n, // no valid after
+          opFinalizationTimeout: 0n, // no op finalization timeout
+          opPendingReceiver: ZERO_ADDRESS, // no op pending receiver
+          opPendingBodyVal: 0n, // no op pending body
         },
         rootMetadata: {
           chainId: 0n, // no chain ID

--- a/contracts/wrappers/mcms/RBACTimelock.ts
+++ b/contracts/wrappers/mcms/RBACTimelock.ts
@@ -16,7 +16,7 @@ import { uint8ArrayToBigInt } from '../../src/utils'
 
 // @dev Initializes the contract
 export type Init = {
-  // Query ID of the change owner request.
+  // Query ID of the change request.
   queryId: bigint
 
   // Minimum delay in seconds for future operations.
@@ -34,13 +34,13 @@ export type Init = {
 
 // @dev Top up contract with TON coins.
 export type TopUp = {
-  // Query ID of the change owner request.
+  // Query ID of the change request.
   queryId: bigint
 }
 
 // @dev Schedule an operation containing a batch of transactions.
 export type ScheduleBatch = {
-  // Query ID of the change owner request.
+  // Query ID of the change request.
   queryId: bigint
 
   // Array of calls to be scheduled
@@ -55,7 +55,7 @@ export type ScheduleBatch = {
 
 // @dev Cancel an operation.
 export type Cancel = {
-  // Query ID of the change owner request.
+  // Query ID of the change request.
   queryId: bigint
 
   // ID of the operation to cancel.
@@ -64,7 +64,7 @@ export type Cancel = {
 
 // @dev Execute an (ready) operation containing a batch of transactions.
 export type ExecuteBatch = {
-  // Query ID of the change owner request.
+  // Query ID of the change request.
   queryId: bigint
 
   // Array of calls to be scheduled
@@ -77,7 +77,7 @@ export type ExecuteBatch = {
 
 // @dev Changes the minimum timelock duration for future operations.
 export type UpdateDelay = {
-  // Query ID of the change owner request.
+  // Query ID of the change request.
   queryId: bigint
 
   // New minimum delay in seconds for future operations.
@@ -86,7 +86,7 @@ export type UpdateDelay = {
 
 // @dev Blocks a function selector from being used
 export type BlockFunctionSelector = {
-  // Query ID of the change owner request.
+  // Query ID of the change request.
   queryId: bigint
 
   // Function selector to block.
@@ -95,7 +95,7 @@ export type BlockFunctionSelector = {
 
 // @dev Unblocks a previously blocked function selector so it can be used again.
 export type UnblockFunctionSelector = {
-  /// Query ID of the change owner request.
+  /// Query ID of the change request.
   queryId: bigint
 
   /// Function selector to unblock.
@@ -104,7 +104,7 @@ export type UnblockFunctionSelector = {
 
 // @dev Directly execute a batch of transactions, bypassing any other checks.
 export type BypasserExecuteBatch = {
-  // Query ID of the change owner request.
+  // Query ID of the change request.
   queryId: bigint
 
   // Array of calls to be scheduled

--- a/docs/contracts/overview/libraries/ownable_2step.drawio.svg
+++ b/docs/contracts/overview/libraries/ownable_2step.drawio.svg
@@ -93,7 +93,7 @@
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
                                     <div>
                                         <font color="#000000" style="color: light-dark(rgb(0, 0, 0), rgb(237, 237, 237));">
-                                            /// Query ID of the change owner request.
+                                            /// Query ID of the change request.
                                         </font>
                                     </div>
                                     <div>
@@ -156,7 +156,7 @@
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
                                     <div>
                                         <font color="#000000" style="color: light-dark(rgb(0, 0, 0), rgb(237, 237, 237));">
-                                            /// Query ID of the change owner request.
+                                            /// Query ID of the change request.
                                         </font>
                                     </div>
                                     <div>
@@ -311,7 +311,7 @@
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
                                     <div>
                                         <font color="#000000" style="color: light-dark(rgb(0, 0, 0), rgb(237, 237, 237));">
-                                            /// Query ID of the change owner request.
+                                            /// Query ID of the change request.
                                         </font>
                                     </div>
                                     <div>
@@ -364,7 +364,7 @@
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
                                     <div>
                                         <font color="#000000" style="color: light-dark(rgb(0, 0, 0), rgb(237, 237, 237));">
-                                            /// Query ID of the change owner request.
+                                            /// Query ID of the change request.
                                         </font>
                                     </div>
                                     <div>

--- a/docs/contracts/overview/mcms/rbac_timelock.drawio.svg
+++ b/docs/contracts/overview/mcms/rbac_timelock.drawio.svg
@@ -497,7 +497,7 @@
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ededed); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
                                     <div>
                                         <font>
-                                            /// Query ID of the change owner request.
+                                            /// Query ID of the change request.
                                         </font>
                                     </div>
                                     <div>
@@ -586,7 +586,7 @@
                         </div>
                     </foreignObject>
                     <text x="297" y="1071" fill="#000000" font-family="&quot;Helvetica&quot;" font-size="12px">
-                        /// Query ID of the change owner request....
+                        /// Query ID of the change request....
                     </text>
                 </switch>
             </g>

--- a/pkg/bindings/lib/access/rbac/types.go
+++ b/pkg/bindings/lib/access/rbac/types.go
@@ -22,7 +22,7 @@ import (
 type GrantRole struct {
 	_ tlb.Magic `tlb:"#95cd540f"` //nolint:revive // (opcode) should stay uninitialized
 
-	// Query ID of the change owner request.
+	// Query ID of the change request.
 	QueryID uint64 `tlb:"## 64"`
 
 	Role    *big.Int         `tlb:"## 256"` // Role definition.
@@ -41,7 +41,7 @@ type GrantRole struct {
 type RevokeRole struct {
 	_ tlb.Magic `tlb:"#969b0db9"` //nolint:revive // (opcode) should stay uninitialized
 
-	// Query ID of the change owner request.
+	// Query ID of the change request.
 	QueryID uint64 `tlb:"## 64"`
 
 	Role    *big.Int         `tlb:"## 256"` // Role definition.
@@ -65,7 +65,7 @@ type RevokeRole struct {
 type RenounceRole struct {
 	_ tlb.Magic `tlb:"#39452c46"` //nolint:revive // (opcode) should stay uninitialized
 
-	// Query ID of the change owner request.
+	// Query ID of the change request.
 	QueryID uint64 `tlb:"## 64"`
 
 	Role               *big.Int         `tlb:"## 256"` // Role definition.
@@ -81,7 +81,7 @@ type RenounceRole struct {
 type RoleGranted struct {
 	_ tlb.Magic `tlb:"#cf3ca837"` //nolint:revive // (opcode) should stay uninitialized
 
-	// Query ID of the change owner request.
+	// Query ID of the change request.
 	QueryID uint64 `tlb:"## 64"`
 
 	Role    *big.Int         `tlb:"## 256"` // Role definition.
@@ -98,7 +98,7 @@ type RoleGranted struct {
 type RoleRevoked struct {
 	_ tlb.Magic `tlb:"#990fe1c7"` //nolint:revive // (opcode) should stay uninitialized
 
-	// Query ID of the change owner request.
+	// Query ID of the change request.
 	QueryID uint64 `tlb:"## 64"`
 
 	Role    *big.Int         `tlb:"## 256"` // Role definition.
@@ -113,7 +113,7 @@ type RoleRevoked struct {
 type RoleAdminChanged struct {
 	_ tlb.Magic `tlb:"#bd7e8bce"` //nolint:revive // (opcode) should stay uninitialized
 
-	// Query ID of the change owner request.
+	// Query ID of the change request.
 	QueryID uint64 `tlb:"## 64"`
 
 	Role              *big.Int `tlb:"## 256"` // Role definition.

--- a/pkg/bindings/mcms/mcms/types.go
+++ b/pkg/bindings/mcms/mcms/types.go
@@ -18,7 +18,7 @@ import (
 // Contract might receive/hold TON as part of the maintenance process.
 type TopUp struct {
 	_ tlb.Magic `tlb:"#5f427bb3"` //nolint:revive // (opcode) should stay uninitialized
-	// Query ID of the change owner request.
+	// Query ID of the change request.
 	QueryID uint64 `tlb:"## 64"`
 }
 
@@ -39,7 +39,7 @@ type TopUp struct {
 type SetRoot struct {
 	_ tlb.Magic `tlb:"#e7fabde3"` //nolint:revive // (opcode) should stay uninitialized
 
-	// Query ID of the change owner request.
+	// Query ID of the change request.
 	QueryID uint64 `tlb:"## 64"`
 
 	Root       *big.Int `tlb:"## 256"` // The new expiring root.
@@ -66,7 +66,7 @@ type SetRoot struct {
 // We expect callees to revert if they run out of gas.
 type Execute struct {
 	_ tlb.Magic `tlb:"#9b9ce96a"` //nolint:revive // (opcode) should stay uninitialized
-	// Query ID of the change owner request.
+	// Query ID of the change request.
 	QueryID uint64 `tlb:"## 64"`
 
 	Op    Op                      `tlb:"^"` // The op to be executed. // Cell<Op>
@@ -92,7 +92,7 @@ type Execute struct {
 // some previous signers aren't trusted any more.
 type SetConfig struct {
 	_ tlb.Magic `tlb:"#89277f4b"` //nolint:revive // (opcode) should stay uninitialized
-	// Query ID of the change owner request.
+	// Query ID of the change request.
 	QueryID uint64 `tlb:"## 64"`
 
 	SignerKeys   common.SnakeData[*big.Int] `tlb:"^"`      // vec<uint256>
@@ -108,7 +108,7 @@ type SetConfig struct {
 type NewRoot struct {
 	_ tlb.Magic `tlb:"#a6533a3d"` //nolint:revive // (opcode) should stay uninitialized
 
-	// Query ID of the change owner request.
+	// Query ID of the change request.
 	QueryID uint64 `tlb:"## 64"`
 
 	Root       *big.Int     `tlb:"## 256"` // The new expiring root.
@@ -120,7 +120,7 @@ type NewRoot struct {
 type ConfigSet struct {
 	_ tlb.Magic `tlb:"#d80be574"` //nolint:revive // (opcode) should stay uninitialized
 
-	// Query ID of the change owner request.
+	// Query ID of the change request.
 	QueryID uint64 `tlb:"## 64"`
 
 	Config        Config `tlb:"."`    // The new config.
@@ -131,7 +131,7 @@ type ConfigSet struct {
 type OpExecuted struct {
 	_ tlb.Magic `tlb:"#7cf37cbf"` //nolint:revive // (opcode) should stay uninitialized
 
-	// Query ID of the change owner request.
+	// Query ID of the change request.
 	QueryID uint64 `tlb:"## 64"`
 
 	Nonce uint64           `tlb:"## 40"` // The nonce of the operation.

--- a/pkg/bindings/mcms/mcms/types.go
+++ b/pkg/bindings/mcms/mcms/types.go
@@ -102,6 +102,34 @@ type SetConfig struct {
 	ClearRoot    bool                       `tlb:"bool"`
 }
 
+// Submit an oracle error report, which marks the current root as invalid.
+//
+// The error report is used for a category of errors which might occur during execution
+// of an operation, but can't be caught on-chain (OOG errors, and downstream tx-trace errors).
+//
+// @dev The error oracle can only report errors for the current non-expired root, to avoid reporting
+// stale errors for operations that are no longer valid.
+type SubmitErrorReport struct {
+	_ tlb.Magic `tlb:"#43ebc734"` //nolint:revive // (opcode) should stay uninitialized
+	// Query ID of the change request.
+	QueryID uint64 `tlb:"## 64"`
+
+	Op       Op                      `tlb:"^"`      // The operation which produced the error. // Cell<Op>
+	Proof    common.SnakeData[Proof] `tlb:"^"`      // The MerkleProof for the op's inclusion in the MerkleTree // vec<uint256>
+	OpTxHash *big.Int                `tlb:"## 256"` // The hash of the execute transaction.
+
+	ErrorTxHash *big.Int `tlb:"## 256"` // The hash of the transaction which errored (part of the tx trace).
+	ErrorCode   uint32   `tlb:"## 32"`  // The error code.
+}
+
+// Message sent by the owner to transfer the oracle role.
+type TransferOracleRole struct {
+	// Query ID of the change request.
+	QueryID uint64 `tlb:"## 64"`
+
+	NewOracle *address.Address `tlb:"addr"` // The address of the new oracle.
+}
+
 // --- Messages - outgoing ---
 
 // @notice Emitted when a new root is set.

--- a/pkg/bindings/mcms/mcms/types.go
+++ b/pkg/bindings/mcms/mcms/types.go
@@ -50,7 +50,7 @@ type SetRoot struct {
 	Signatures    common.SnakeData[ocr.SignatureEd25519] `tlb:"^"` // The ECDSA signatures on (root, validUntil). // vec<Signature>
 }
 
-// @notice Execute the received op after verifying the proof of its inclusion in the
+// Execute the received op after verifying the proof of its inclusion in the
 // current Merkle tree. The op should be the next op according to the order
 // enforced by the merkle tree whose root is stored in data.expiringRootAndOpCount, i.e., the
 // nonce of the op should be equal to data.expiringRootAndOpCount.opCount.
@@ -73,7 +73,7 @@ type Execute struct {
 	Proof common.SnakeData[Proof] `tlb:"^"` // The MerkleProof for the op's inclusion in the MerkleTree // vec<uint256>
 }
 
-// @notice sets a new data.config. If clearRoot is true, then it also invalidates
+// Sets a new data.config. If clearRoot is true, then it also invalidates
 // data.expiringRootAndOpCount.root.
 //
 // @param signerKeys holds the public keys of the active signers. The keys must be in
@@ -95,11 +95,11 @@ type SetConfig struct {
 	// Query ID of the change request.
 	QueryID uint64 `tlb:"## 64"`
 
-	SignerKeys   common.SnakeData[*big.Int] `tlb:"^"`      // vec<uint256>
-	SignerGroups common.SnakeData[uint8]    `tlb:"^"`      // vec<uint8>
-	GroupQuorums *cell.Dictionary           `tlb:"dict 8"` // map<uint8, uint8> (indexed, iterable backwards)
-	GroupParents *cell.Dictionary           `tlb:"dict 8"` // map<uint8, uint8> (indexed, iterable backwards)
-	ClearRoot    bool                       `tlb:"bool"`
+	SignerKeys   common.SnakeData[SignerKey] `tlb:"^"`      // vec<uint256>
+	SignerGroups common.SnakeData[uint8]     `tlb:"^"`      // vec<uint8>
+	GroupQuorums *cell.Dictionary            `tlb:"dict 8"` // map<uint8, uint8> (indexed, iterable backwards)
+	GroupParents *cell.Dictionary            `tlb:"dict 8"` // map<uint8, uint8> (indexed, iterable backwards)
+	ClearRoot    bool                        `tlb:"bool"`
 }
 
 // Submit an oracle error report, which marks the current root as invalid.
@@ -132,7 +132,7 @@ type TransferOracleRole struct {
 
 // --- Messages - outgoing ---
 
-// @notice Emitted when a new root is set.
+// Sent back to sender when a new root is set.
 type NewRoot struct {
 	_ tlb.Magic `tlb:"#a6533a3d"` //nolint:revive // (opcode) should stay uninitialized
 
@@ -144,7 +144,7 @@ type NewRoot struct {
 	Metadata   RootMetadata `tlb:"."`      // The metadata about the root, which is stored as one of the leaves.
 }
 
-// @notice Emitted when a new config is set.
+// Sent back to sender when a new config is set.
 type ConfigSet struct {
 	_ tlb.Magic `tlb:"#d80be574"` //nolint:revive // (opcode) should stay uninitialized
 
@@ -155,7 +155,7 @@ type ConfigSet struct {
 	IsRootCleared bool   `tlb:"bool"` // Whether the root was cleared.
 }
 
-// @notice Emitted when an op gets successfully executed.
+// Sent back to sender when an op gets successfully executed.
 type OpExecuted struct {
 	_ tlb.Magic `tlb:"#7cf37cbf"` //nolint:revive // (opcode) should stay uninitialized
 
@@ -168,9 +168,41 @@ type OpExecuted struct {
 	Value tlb.Coins        `tlb:"^"`     // The value to be sent with the operation. // coins
 }
 
+// Sent back to sender when an error report is successfully submitted.
+type ErrorReportSubmitted struct {
+	_ tlb.Magic `tlb:"#bbc4deb4"` //nolint:revive // (opcode) should stay uninitialized
+
+	// Query ID of the change request.
+	QueryID uint64 `tlb:"## 64"`
+
+	OpLeafHash *big.Int `tlb:"## 256"` // The (merkle leaf) hash of the operation which produced the error.
+	OpTxHash   *big.Int `tlb:"## 256"` // The hash of the operation execute transaction.
+
+	ErrorTxHash *big.Int `tlb:"## 256"` // The hash of the transaction which errored.
+	ErrorCode   uint32   `tlb:"## 32"`  // The error code.
+
+	Root             *cell.Cell `tlb:"^"`    // The current root which was invalidated. // Cell<uint256>
+	MatchesPendingOp bool       `tlb:"bool"` // Whether the operation that was pending was the one for which the error was reported.
+}
+
+// Sent back to sender when the oracle role is transferred.
+type OracleRoleTransferred struct {
+	_ tlb.Magic `tlb:"#ff4176a3"` //nolint:revive // (opcode) should stay uninitialized
+
+	// Query ID of the change request.
+	QueryID uint64 `tlb:"## 64"`
+
+	OldOracle *address.Address `tlb:"addr"` // The address of the old oracle.
+	NewOracle *address.Address `tlb:"addr"` // The address of the new oracle.
+}
+
 // -- Data structures ---
 
 type Proof struct {
+	Value *big.Int `tlb:"## 256"` // The value of the struct
+}
+
+type SignerKey struct {
 	Value *big.Int `tlb:"## 256"` // The value of the struct
 }
 
@@ -237,7 +269,7 @@ type Config struct {
 	GroupParents *cell.Dictionary `tlb:"dict 8"` // map<uint8, uint8> (indexed, iterable backwards)
 }
 
-// @notice Each root also authenticates metadata about itself (stored as one of the leaves)
+// Each root also authenticates metadata about itself (stored as one of the leaves)
 // which must be revealed when the root is set.
 //
 // @dev We need to be careful that abi.encode(MANY_CHAIN_MULTI_SIG_DOMAIN_SEPARATOR_METADATA, RootMetadata)
@@ -263,7 +295,7 @@ type RootMetadata struct {
 	OverridePreviousRoot bool `tlb:"bool"`
 }
 
-// @notice an op to be executed by the ManyChainMultiSig contract
+// An op to be executed by the ManyChainMultiSig contract
 type Op struct {
 	ChainID  *big.Int         `tlb:"## 256"` // The chain ID of the operation.
 	MultiSig *address.Address `tlb:"addr"`   // The address of the multisig contract.
@@ -358,4 +390,13 @@ const (
 
 	// Thrown when attempt to set the same (root, validUntil) in setRoot().
 	ErrorSignedHashAlreadySeen = 121
+
+	/// Thrown when the root has not been finalized yet (can't execute next op before finalization).
+	ErrorRootNotFinalized = 122
+
+	/// Thrown when the provided op.value is insufficient (min required value not met).
+	ErrorInsufficientValue = 123
+
+	/// Thrown when the error report sender is not the authorized oracle.
+	ErrorUnauthorizedOracle = 124
 )

--- a/pkg/bindings/mcms/timelock/types.go
+++ b/pkg/bindings/mcms/timelock/types.go
@@ -23,7 +23,7 @@ import (
 // - `bypassers`: accounts to be granted bypasser role
 type Init struct {
 	_ tlb.Magic `tlb:"#4982fcfd"` //nolint:revive // (opcode) should stay uninitialized
-	// Query ID of the change owner request.
+	// Query ID of the change request.
 	QueryID uint64 `tlb:"## 64"`
 
 	// Minimum delay in seconds for future operations.
@@ -43,7 +43,7 @@ type Init struct {
 // Contract might receive/hold TON as part of the maintenance process.
 type TopUp struct {
 	_ tlb.Magic `tlb:"#fee62ba6"` //nolint:revive // (opcode) should stay uninitialized
-	// Query ID of the change owner request.
+	// Query ID of the change request.
 	QueryID uint64 `tlb:"## 64"`
 }
 
@@ -57,7 +57,7 @@ type TopUp struct {
 // - all payloads must not start with a blocked function selector.
 type ScheduleBatch struct {
 	_ tlb.Magic `tlb:"#094718f4"` //nolint:revive // (opcode) should stay uninitialized
-	// Query ID of the change owner request.
+	// Query ID of the change request.
 	QueryID uint64 `tlb:"## 64"`
 
 	Calls       common.SnakeData[Call] `tlb:"^"`      // Array of calls to be scheduled // vec<Timelock_Call>
@@ -73,7 +73,7 @@ type ScheduleBatch struct {
 // - the caller must have the 'canceller' or 'admin' role.
 type Cancel struct {
 	_ tlb.Magic `tlb:"#af3bf1d0"` //nolint:revive // (opcode) should stay uninitialized
-	// Query ID of the change owner request.
+	// Query ID of the change request.
 	QueryID uint64 `tlb:"## 64"`
 
 	// ID of the operation to cancel.
@@ -89,7 +89,7 @@ type Cancel struct {
 // - the caller must have the 'executor' or 'admin' role.
 type ExecuteBatch struct {
 	_ tlb.Magic `tlb:"#6e9bf263"` //nolint:revive // (opcode) should stay uninitialized
-	// Query ID of the change owner request.
+	// Query ID of the change request.
 	QueryID uint64 `tlb:"## 64"`
 
 	Calls       common.SnakeData[Call] `tlb:"^"`      // Array of calls to be scheduled // vec<Timelock_Call>
@@ -106,7 +106,7 @@ type ExecuteBatch struct {
 // - the caller must have the 'admin' role.
 type UpdateDelay struct {
 	_ tlb.Magic `tlb:"#7a57a45c"` //nolint:revive // (opcode) should stay uninitialized
-	// Query ID of the change owner request.
+	// Query ID of the change request.
 	QueryID uint64 `tlb:"## 64"`
 
 	// New minimum delay in seconds for future operations.
@@ -125,7 +125,7 @@ type UpdateDelay struct {
 // - the caller must have the 'admin' role.
 type BlockFunctionSelector struct {
 	_ tlb.Magic `tlb:"#2637af77"` //nolint:revive // (opcode) should stay uninitialized
-	// Query ID of the change owner request.
+	// Query ID of the change request.
 	QueryID uint64 `tlb:"## 64"`
 
 	// Function selector to block.
@@ -139,7 +139,7 @@ type BlockFunctionSelector struct {
 // - the caller must have the 'admin' role.
 type UnblockFunctionSelector struct {
 	_ tlb.Magic `tlb:"#26f19f4e"` //nolint:revive // (opcode) should stay uninitialized
-	// Query ID of the change owner request.
+	// Query ID of the change request.
 	QueryID uint64 `tlb:"## 64"`
 
 	// Function selector to unblock.
@@ -155,7 +155,7 @@ type UnblockFunctionSelector struct {
 // - the caller must have the 'bypasser' or 'admin' role.
 type BypasserExecuteBatch struct {
 	_ tlb.Magic `tlb:"#bb0e9f7d"` //nolint:revive // (opcode) should stay uninitialized
-	// Query ID of the change owner request.
+	// Query ID of the change request.
 	QueryID uint64 `tlb:"## 64"`
 
 	// Array of calls to be scheduled
@@ -167,7 +167,7 @@ type BypasserExecuteBatch struct {
 // @dev Emitted when a call is scheduled as part of operation `id`.
 type CallScheduled struct {
 	_ tlb.Magic `tlb:"#c55fca54"` //nolint:revive // (opcode) should stay uninitialized
-	// Query ID of the change owner request.
+	// Query ID of the change request.
 	QueryID uint64 `tlb:"## 64"`
 
 	ID          *big.Int `tlb:"## 256"` // ID of the operation that was scheduled.
@@ -181,7 +181,7 @@ type CallScheduled struct {
 // @dev Emitted when a call is performed as part of operation `id`.
 type CallExecuted struct {
 	_ tlb.Magic `tlb:"#49ea5d0e"` //nolint:revive // (opcode) should stay uninitialized
-	// Query ID of the change owner request.
+	// Query ID of the change request.
 	QueryID uint64 `tlb:"## 64"`
 
 	ID     *big.Int        `tlb:"## 256"` // ID of the operation that was executed.
@@ -194,7 +194,7 @@ type CallExecuted struct {
 // @dev Emitted when a call is performed via bypasser.
 type BypasserCallExecuted struct {
 	_ tlb.Magic `tlb:"#9c7f3010"` //nolint:revive // (opcode) should stay uninitialized
-	// Query ID of the change owner request.
+	// Query ID of the change request.
 	QueryID uint64 `tlb:"## 64"`
 
 	Index  uint64          `tlb:"## 64"` // Index of the call in the operation
@@ -206,7 +206,7 @@ type BypasserCallExecuted struct {
 // @dev Emitted when operation `id` is cancelled.
 type Cancelled struct {
 	_ tlb.Magic `tlb:"#580e80f2"` //nolint:revive // (opcode) should stay uninitialized
-	// Query ID of the change owner request.
+	// Query ID of the change request.
 	QueryID uint64 `tlb:"## 64"`
 
 	ID *big.Int `tlb:"## 256"` // ID of the operation that was cancelled.
@@ -215,7 +215,7 @@ type Cancelled struct {
 // @dev Emitted when the minimum delay for future operations is modified.
 type MinDelayChange struct {
 	_ tlb.Magic `tlb:"#904b14e0"` //nolint:revive // (opcode) should stay uninitialized
-	// Query ID of the change owner request.
+	// Query ID of the change request.
 	QueryID uint64 `tlb:"## 64"`
 
 	OldDuration uint64 `tlb:"## 64"` // Duration of the old minimum delay in seconds.
@@ -225,7 +225,7 @@ type MinDelayChange struct {
 // @dev Emitted when a function selector is blocked.
 type FunctionSelectorBlocked struct {
 	_ tlb.Magic `tlb:"#9c4d6d94"` //nolint:revive // (opcode) should stay uninitialized
-	// Query ID of the change owner request.
+	// Query ID of the change request.
 	QueryID uint64 `tlb:"## 64"`
 
 	// Function selector that was blocked.
@@ -235,7 +235,7 @@ type FunctionSelectorBlocked struct {
 // @dev Emitted when a function selector is unblocked.
 type FunctionSelectorUnblocked struct {
 	_ tlb.Magic `tlb:"#f410a31b"` //nolint:revive // (opcode) should stay uninitialized
-	// Query ID of the change owner request.
+	// Query ID of the change request.
 	QueryID uint64 `tlb:"## 64"`
 
 	// Function selector that was unblocked.


### PR DESCRIPTION
This PR adds op execution tracking (state + logic) and a concept of an (error) oracle which can report errors which can not be easily caught on-chain (e.g., out-of-gas error, trace downstream errors).

- [x] Adds `oracle: address` to  MCMS contract data -  account which can submit error reports.
- [x] Adds `OpPendingInfo` to `ExpiringRootAndOpCount` (current root state) to track current execution
- [x] Adds  `onBouncedMessage` handler
- [x] Adds `MCMS_SubmitErrorReport` msg + handler
- [x] Adds `MCMS_TransferOracleRole` msg + handler

```go
// @dev we set optimistic finalization of an async operation using a timeout
// Within that timeout executions are paused as we wait for the finalization signal
//
// To finalize an execution, one of two conditions must be met:
// 1. Finalization timeout expired                      [can continue]
// 2. Message bounced back                              [can retry]
// 3. Oracle reported an error (e.g., out-of-gas error) [root invalidated, can't retry]
```