### PR TITLE
[NONEVM-2521] Stop running short tests

### DIFF
--- a/.github/workflows/relayer-integration-test.yml
+++ b/.github/workflows/relayer-integration-test.yml
@@ -17,7 +17,9 @@ jobs:
       # run both suites even if one fails
       fail-fast: false
       matrix:
-        test-suite: ["short", "all"]
+        # We currently don't have a big time difference between short and all tests, but this can be reenabled in the future.
+        # test-suite: ["short", "all"]
+        test-suite: ["all"]
 
     steps:
       - name: Check out code
@@ -47,4 +49,3 @@ jobs:
             echo "Running all tests..."
             nix develop .#ccip-e2e -c go test -v -count=1 -p=1 -timeout 30m ./...
           fi
-


### PR DESCRIPTION
[NONEVM-2521](https://smartcontract-it.atlassian.net/browse/NONEVM-2521)

There is only a 4' difference between short and all tests, and we are running them concurrently.

[NONEVM-2521]: https://smartcontract-it.atlassian.net/browse/NONEVM-2521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ