### PR TITLE
Fix changesets workflow permissions

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -28,6 +28,6 @@ jobs:
           # Except the root package, which is tagged like: v<version> (Go module convention)
           changesets-root-version-package-path: ./pkg/package.json
           pnpm-use-cache: false
-          aws-region: us-west-2
-          aws-role-arn: ${{ secrets.AWS_ROLE_ARN_GATI_READONLY }}
+          aws-region: ${{ vars.AWS_REGION }}
+          aws-role-arn: ${{ secrets.AWS_ROLE_ARN_GATI_READONLY_CHANGESETS }}
           aws-lambda-url: ${{ secrets.AWS_LAMBDA_URL_GATI_CHANGESETS }}


### PR DESCRIPTION
This PR updates the changesets workflow configuration to use variable-based AWS region configuration and a changesets-specific AWS role ARN for improved permissions management.

- Replace hardcoded AWS region with a repository variable
- Switch to a changesets-specific AWS role ARN secret
