### PR TITLE
[NONEVM-4759] [TXM] Add expiration check in broadcastLoop before broadcast

### DIFF
--- a/integration-tests/txm/txm_test.go
+++ b/integration-tests/txm/txm_test.go
@@ -44,7 +44,7 @@ func TestTxmLocal(t *testing.T) {
 	}
 
 	type TestSetup struct {
-		startTXM         func(logger.Logger) *txm.Txm
+		startTXM         func(logger.Logger, ...txm.Config) *txm.Txm
 		txmTestingClient *testingAPIClientWrapped
 		setupClient      tracetracking.SignedAPIClient
 	}
@@ -297,6 +297,37 @@ func TestTxmLocal(t *testing.T) {
 					entries := logs.FilterMessage("transaction did not produce any outgoing messages, this may indicate that the value of the enqueued message was higher than the balance of the account").FilterLevelExact(zapcore.ErrorLevel)
 					require.GreaterOrEqual(t, entries.Len(), 1, "expected TXM to log error")
 				}
+			}}, {
+			name: "ExpiredTransaction",
+			test: func(t *testing.T, setup TestSetup) {
+				lggr := test_logger.New()
+				// Use a very short TxExpiration so the transaction expires before broadcast
+				config := txm.DefaultConfigSet
+				config.ConfirmPollInterval = commonconfig.MustNewDuration(2 * time.Second)
+				config.TxExpiration = commonconfig.MustNewDuration(0)
+
+				tonTxm := setup.startTXM(lggr, config)
+				t.Cleanup(func() { require.NoError(t, tonTxm.Close(), "Fail to close TXM") })
+
+				setup.txmTestingClient.On("SendWaitTransaction", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+					t.Fatal("Mock SendWaitTransaction called. This should not happen because the transaction should expire before it is sent.")
+				}).Maybe()
+
+				// Deploy counter contract
+				const initialValue uint32 = 0
+				counterAddr := deployCounterContract(t, setup.setupClient.Wallet, initialValue)
+
+				err := tonTxm.Enqueue(txm.Request{
+					Mode:            wallet.PayGasSeparately | wallet.IgnoreErrors,
+					FromWallet:      setup.setupClient.Wallet,
+					ContractAddress: *counterAddr,
+					Amount:          tlb.MustFromTON("0.05"),
+					Bounce:          true,
+					Body:            tvm.EmptyCell,
+				})
+				require.NoError(t, err)
+
+				waitForStableInflightCount(lggr, tonTxm, 5*time.Second)
 			}},
 	}
 
@@ -307,16 +338,24 @@ func TestTxmLocal(t *testing.T) {
 			tc.test(t, TestSetup{
 				setupClient:      accounts[i].setupClient,
 				txmTestingClient: accounts[i].txmTestingClient,
-				startTXM: func(lggr logger.Logger) *txm.Txm {
-					config := txm.DefaultConfigSet
-					config.ConfirmPollInterval = commonconfig.MustNewDuration(2 * time.Second)
+				startTXM: func(lggr logger.Logger, config ...txm.Config) *txm.Txm {
+					configToBeSet := txm.Config{
+						ConfirmPollInterval: commonconfig.MustNewDuration(2 * time.Second),
+					}
+					if len(config) > 0 {
+						configToBeSet = config[0]
+						if configToBeSet.ConfirmPollInterval == nil {
+							configToBeSet.ConfirmPollInterval = commonconfig.MustNewDuration(2 * time.Second)
+						}
+					}
+					configToBeSet.ApplyDefaults()
 
 					chainID := string(chainsel.TON_LOCALNET.ChainID)
 
 					signedClientProvider := func(ctx context.Context) (tracetracking.SignedAPIClient, error) {
 						return accounts[i].txmSignedAPIClient, nil
 					}
-					tonTxm, err := txm.New(lggr, chainID, keystore, signedClientProvider, config)
+					tonTxm, err := txm.New(lggr, chainID, keystore, signedClientProvider, configToBeSet)
 					require.NoError(t, err)
 					err = tonTxm.Start(t.Context())
 					require.NoError(t, err)

--- a/pkg/txm/txm.go
+++ b/pkg/txm/txm.go
@@ -229,20 +229,6 @@ func (t *Txm) broadcastLoop() {
 				return
 			}
 
-			txID := "none"
-			if tx.ID != nil {
-				txID = *tx.ID
-			}
-
-			if !time.Now().Before(tx.Expiration) {
-				t.logger.Warnw("transaction expired before broadcast, skipping",
-					"txID", txID,
-					"to", tx.To.String(),
-					"amount", tx.Amount.Nano().String(),
-					"expiration", tx.Expiration.String())
-				continue
-			}
-
 			t.logger.Debugw("broadcasting transaction", "to", tx.To.String(), "amount", tx.Amount.Nano().String())
 
 			var st tlb.StateInit
@@ -271,6 +257,10 @@ func (t *Txm) broadcastLoop() {
 			}
 
 			// 3. Sign and send
+			txID := "none"
+			if tx.ID != nil {
+				txID = *tx.ID
+			}
 			bodyBOC := "none"
 			if tx.Body != nil {
 				bodyBOC = hex.EncodeToString(tx.Body.ToBOC())
@@ -314,6 +304,15 @@ func (t *Txm) broadcastWithRetry(ctx context.Context, tx *Tx, msg *wallet.Messag
 	// try to broadcast transaction
 retryLoop:
 	for attempt := uint(1); attempt <= t.config.MaxSendRetryAttempts; attempt++ {
+		if !time.Now().Before(tx.Expiration) {
+			t.logger.Warnw("transaction expired",
+				"txID", txID,
+				"to", tx.To.String(),
+				"amount", tx.Amount.Nano().String(),
+				"expiration", tx.Expiration.String())
+			return errors.New("transaction expired, not broadcasting")
+		}
+
 		t.logger.Debugw("sending transaction to TON",
 			"txID", txID,
 			"attempt", attempt,

--- a/pkg/txm/txm.go
+++ b/pkg/txm/txm.go
@@ -229,6 +229,20 @@ func (t *Txm) broadcastLoop() {
 				return
 			}
 
+			txID := "none"
+			if tx.ID != nil {
+				txID = *tx.ID
+			}
+
+			if !time.Now().Before(tx.Expiration) {
+				t.logger.Warnw("transaction expired before broadcast, skipping",
+					"txID", txID,
+					"to", tx.To.String(),
+					"amount", tx.Amount.Nano().String(),
+					"expiration", tx.Expiration.String())
+				continue
+			}
+
 			t.logger.Debugw("broadcasting transaction", "to", tx.To.String(), "amount", tx.Amount.Nano().String())
 
 			var st tlb.StateInit
@@ -257,10 +271,6 @@ func (t *Txm) broadcastLoop() {
 			}
 
 			// 3. Sign and send
-			txID := "none"
-			if tx.ID != nil {
-				txID = *tx.ID
-			}
 			bodyBOC := "none"
 			if tx.Body != nil {
 				bodyBOC = hex.EncodeToString(tx.Body.ToBOC())


### PR DESCRIPTION
[NONEVM-4759](https://smartcontract-it.atlassian.net/browse/NONEVM-4759)

Depends on https://github.com/smartcontractkit/chainlink-ton/pull/726

[NONEVM-4759]: https://smartcontract-it.atlassian.net/browse/NONEVM-4759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ