### PR TITLE
[NONEVM-4760] [TXM] Classify "insufficient funds" as fatal in broadcastWithRetry

### DIFF
--- a/docs/contracts/overview/ccip/offramp/arbitrary-msg.md
+++ b/docs/contracts/overview/ccip/offramp/arbitrary-msg.md
@@ -37,7 +37,7 @@ sequenceDiagram
 
     
     
-    Note over OR: RECEIVES from OCR transmiter Commit<br>{ queryId, reportContext, report, signatures }
+    Note over OR: RECEIVES from OCR transmitter Commit<br>{ queryId, reportContext, report, signatures }
     activate OR
 
     create participant MR as MerkleRoot{id}

--- a/integration-tests/ocr/ocr_test.go
+++ b/integration-tests/ocr/ocr_test.go
@@ -71,17 +71,18 @@ func TestTransmitterLocal(t *testing.T) {
 				// Each account gets its own independent client connection so that
 				// tests (e.g. UnhealthyRPC) can close a pool without affecting others.
 
-				pool, err := tonchainpkg.CreateLiteserverConnectionPool(t.Context(), tonChain.URL)
+				connectionPool, err := tonchainpkg.CreateLiteserverConnectionPool(t.Context(), tonChain.URL)
 				require.NoError(t, err, "failed to create connection pool from URL")
 
-				client := ton.NewAPIClient(pool, ton.ProofCheckPolicyFast).WithRetry()
+				client := ton.NewAPIClient(connectionPool, ton.ProofCheckPolicyFast).WithRetry()
 
 				recipients[i] = w.Address()
 				amounts[i] = tlb.FromNanoTON(initialAmount)
 
+				signedAPIClient := tracetracking.NewSignedAPIClient(client, *w)
 				accounts[i] = connection{
-					SignedAPIClient: tracetracking.NewSignedAPIClient(client, *w),
-					ConnectionPool:  pool,
+					signedAPIClient,
+					connectionPool,
 				}
 
 				keystore.AddKey(w.PrivateKey())

--- a/integration-tests/testutils/test_logger/logger.go
+++ b/integration-tests/testutils/test_logger/logger.go
@@ -5,12 +5,27 @@ import (
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
 
 // This logger prevents testing framework from printing the path and line number inside the logger package, which is not useful and clutters the logs. Instead, it will print the caller of the logger (i.e. the line in this test file where the log was called).
 func New() logger.Logger {
+	core := loggerCore()
+	return logger.WithOptions(logger.NewWithCores(core), zap.AddCaller())
+}
+
+// This logger is used for tests that need to assert on the logs. It combines the console logger with an observer core, which allows us to capture the logs and make assertions on them in the tests.
+func NewObserved() (logger.Logger, *observer.ObservedLogs) {
+	consoleCore := loggerCore()
+	observerCore, logs := observer.New(zapcore.DebugLevel)
+
+	combined := zapcore.NewTee(consoleCore, observerCore)
+	return logger.WithOptions(logger.NewWithCores(combined), zap.AddCaller()), logs
+}
+
+func loggerCore() zapcore.Core {
 	cfg := zap.NewDevelopmentEncoderConfig()
 	cfg.EncodeTime = zapcore.TimeEncoderOfLayout("15:04:05.000000000")
 	core := zapcore.NewCore(
@@ -18,5 +33,5 @@ func New() logger.Logger {
 		zapcore.Lock(os.Stderr),
 		zapcore.DebugLevel,
 	)
-	return logger.WithOptions(logger.NewWithCores(core), zap.AddCaller())
+	return core
 }

--- a/integration-tests/txm/txm_test.go
+++ b/integration-tests/txm/txm_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/smartcontractkit/chainlink-ton/pkg/bindings"
 	"github.com/smartcontractkit/chainlink-ton/pkg/ccip/bindings/ownable2step"
 	relayer_utils "github.com/smartcontractkit/chainlink-ton/pkg/relay/testutils"
-	"github.com/smartcontractkit/chainlink-ton/pkg/ton/codec/debug"
 	"github.com/smartcontractkit/chainlink-ton/pkg/ton/tracetracking"
 	"github.com/smartcontractkit/chainlink-ton/pkg/ton/tvm"
 	"github.com/smartcontractkit/chainlink-ton/pkg/ton/wrappers"
@@ -172,32 +171,31 @@ func TestTxmLocal(t *testing.T) {
 				const initialValue uint32 = 0
 				counterAddr := deployCounterContract(t, setup.setupClient.Wallet, initialValue)
 
-				// Drain the transmitter's balance
+				unblockSend := make(chan struct{})
+				step := func() { unblockSend <- struct{}{} }
+				// Assert that SendWaitTransaction is called only once, which means Txm is not retrying the transaction after the first failure
+				setup.txmTestingClient.On("SendExternalMessageWaitTransaction", mock.Anything, mock.Anything, mock.Anything).
+					Run(func(args mock.Arguments) {
+						ext := args.Get(1).(*tlb.ExternalMessage)
+						t.Logf("Mock SendWaitTransaction called with dstAddr: %s", ext.DstAddr.String())
+						<-unblockSend
+					}).Twice() // drain tx + tx expected to fail
+
+				// Enqueue tx that will drain the transmitter's balance
 				{
-					msgTrace, err := setup.setupClient.SendAndWaitForTrace(t.Context(), *tvm.ZeroAddress, &wallet.Message{
-						Mode: wallet.IgnoreErrors | wallet.CarryAllRemainingBalance,
-						InternalMessage: &tlb.InternalMessage{
-							DstAddr: tvm.ZeroAddress,
-							Amount:  tlb.MustFromTON("0.1"),
-							Body:    tvm.EmptyCell,
-						},
+					err := tonTxm.Enqueue(txm.Request{
+						Mode:            wallet.IgnoreErrors | wallet.CarryAllRemainingBalance,
+						FromWallet:      setup.setupClient.Wallet,
+						ContractAddress: *tvm.ZeroAddress,
+						Amount:          tlb.MustFromTON("0.1"),
+						Bounce:          false,
+						Body:            tvm.EmptyCell,
 					})
 					require.NoError(t, err)
-
-					t.Logf("Drain trace:\n%s", debug.NewDebuggerTreeTrace(nil).DumpReceived(msgTrace))
-
-					tb := balance.MustGet(t, setup.setupClient.Client, setup.setupClient.Wallet.WalletAddress())
-					require.Truef(t, tb.IsZero(), "Transmitter balance should be zero after depletion, but it is %s", tb.String())
 				}
 
 				// Enqueue valid tx which should now fail due to insufficient funds
 				{
-					// Assert that SendWaitTransaction is called only once, which means Txm is not retrying the transaction after the first failure
-					setup.txmTestingClient.On("SendExternalMessageWaitTransaction", mock.Anything, mock.Anything, mock.Anything).
-						Run(func(args mock.Arguments) {
-							ext := args.Get(1).(*tlb.ExternalMessage)
-							t.Logf("Mock SendWaitTransaction called with dstAddr: %s", ext.DstAddr.String())
-						}).Once()
 					incrementBody, incErr := tlb.ToCell(counter.IncreaseCount{QueryID: 1})
 					require.NoError(t, incErr)
 
@@ -210,8 +208,23 @@ func TestTxmLocal(t *testing.T) {
 						Body:            incrementBody,
 					})
 					require.NoError(t, err)
+				}
 
-					waitForStableInflightCount(lggr, tonTxm, 30*time.Second)
+				{
+					// TMP sleep 3 seconds
+					time.Sleep(3 * time.Second)
+					tbb := balance.MustGet(t, setup.setupClient.Client, setup.setupClient.Wallet.WalletAddress())
+					require.Falsef(t, tbb.IsZero(), "Transmitter balance should not be zero before any tx, but it is %s", tbb.String())
+
+					// Drain balance
+					step()
+					waitForStableInflightCount(lggr, tonTxm, 10*time.Second)
+					tb := balance.MustGet(t, setup.setupClient.Client, setup.setupClient.Wallet.WalletAddress())
+					require.Truef(t, tb.IsZero(), "Transmitter balance should be zero after depletion, but it is %s", tb.String())
+
+					// Unblock SendWaitTransaction for the tx with zero balance and wait for it to process, which should result in an error and not be retried
+					step()
+					waitForStableInflightCount(lggr, tonTxm, 10*time.Second)
 
 					currentValue, err := counter.GetValue(t.Context(), setup.setupClient.Client, counterAddr)
 					require.NoError(t, err)
@@ -230,14 +243,33 @@ func TestTxmLocal(t *testing.T) {
 				const initialValue uint32 = 0
 				counterAddr := deployCounterContract(t, setup.setupClient.Wallet, initialValue)
 
-				// Enqueue valid tx which should now fail due to insufficient funds
+				unblockSend := make(chan struct{})
+				step := func() { unblockSend <- struct{}{} }
+
+				setup.txmTestingClient.On("SendExternalMessageWaitTransaction", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+					ext := args.Get(1).(*tlb.ExternalMessage)
+					t.Logf("Mock SendWaitTransaction called with dstAddr: %s", ext.DstAddr.String())
+					<-unblockSend
+				}).Twice()
+
+				// Enqueue tx that will drain most of the transmitter's balance, leaving insufficient for the next tx
 				{
-					amount := balance.MustGet(t, setup.setupClient.Client, setup.setupClient.Wallet.WalletAddress())
-					// Assert that SendWaitTransaction is called only once, which means Txm is not retrying the transaction after the first failure
-					setup.txmTestingClient.On("SendExternalMessageWaitTransaction", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
-						ext := args.Get(1).(*tlb.ExternalMessage)
-						t.Logf("Mock SendWaitTransaction called with dstAddr: %s", ext.DstAddr.String())
-					}).Once()
+					currentBalance := balance.MustGet(t, setup.setupClient.Client, setup.setupClient.Wallet.WalletAddress())
+					drainAmount := tlb.FromNanoTON(new(big.Int).Sub(currentBalance.Nano(), tlb.MustFromTON("0.02").Nano()))
+
+					err := tonTxm.Enqueue(txm.Request{
+						Mode:            wallet.PayGasSeparately | wallet.IgnoreErrors,
+						FromWallet:      setup.setupClient.Wallet,
+						ContractAddress: *tvm.ZeroAddress,
+						Amount:          drainAmount,
+						Bounce:          false,
+						Body:            tvm.EmptyCell,
+					})
+					require.NoError(t, err)
+				}
+
+				// Enqueue tx which should be rejected by Enqueue due to insufficient funds
+				{
 					incrementBody, incErr := tlb.ToCell(counter.IncreaseCount{QueryID: 1})
 					require.NoError(t, incErr)
 
@@ -245,13 +277,16 @@ func TestTxmLocal(t *testing.T) {
 						Mode:            wallet.PayGasSeparately | wallet.IgnoreErrors,
 						FromWallet:      setup.setupClient.Wallet,
 						ContractAddress: *counterAddr,
-						Amount:          *amount,
+						Amount:          tlb.MustFromTON("0.05"),
 						Bounce:          true,
 						Body:            incrementBody,
 					})
 					require.NoError(t, err)
-
-					waitForStableInflightCount(lggr, tonTxm, 30*time.Second)
+				}
+				{
+					step()
+					step()
+					waitForStableInflightCount(lggr, tonTxm, 10*time.Second)
 
 					currentValue, err := counter.GetValue(t.Context(), setup.setupClient.Client, counterAddr)
 					require.NoError(t, err)

--- a/integration-tests/txm/txm_test.go
+++ b/integration-tests/txm/txm_test.go
@@ -8,64 +8,87 @@ import (
 	"time"
 
 	chainsel "github.com/smartcontractkit/chain-selectors"
-
-	"github.com/smartcontractkit/chainlink-ton/deployment/utils"
-	"github.com/smartcontractkit/chainlink-ton/integration-tests/testutils/test_logger"
+	"go.uber.org/zap/zapcore"
 
 	commonconfig "github.com/smartcontractkit/chainlink-common/pkg/config"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
+	"github.com/smartcontractkit/chainlink-ton/deployment/utils"
+	"github.com/smartcontractkit/chainlink-ton/integration-tests/testutils/test_logger"
+	"github.com/smartcontractkit/chainlink-ton/integration-tests/testutils/ton/balance"
 	"github.com/smartcontractkit/chainlink-ton/pkg/bindings"
 	"github.com/smartcontractkit/chainlink-ton/pkg/ccip/bindings/ownable2step"
 	relayer_utils "github.com/smartcontractkit/chainlink-ton/pkg/relay/testutils"
+	"github.com/smartcontractkit/chainlink-ton/pkg/ton/codec/debug"
 	"github.com/smartcontractkit/chainlink-ton/pkg/ton/tracetracking"
 	"github.com/smartcontractkit/chainlink-ton/pkg/ton/tvm"
 	"github.com/smartcontractkit/chainlink-ton/pkg/ton/wrappers"
 	"github.com/smartcontractkit/chainlink-ton/pkg/txm"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/xssnick/tonutils-go/address"
 	"github.com/xssnick/tonutils-go/tlb"
+	"github.com/xssnick/tonutils-go/ton"
 	"github.com/xssnick/tonutils-go/ton/wallet"
 
 	"github.com/smartcontractkit/chainlink-ton/pkg/bindings/examples/counter"
 )
 
+const networkGlobalID int32 = -217
+
 func TestTxmLocal(t *testing.T) {
+	type connection struct {
+		txmSignedAPIClient tracetracking.SignedAPIClient
+		txmTestingClient   *testingAPIClientWrapped
+		setupClient        tracetracking.SignedAPIClient
+	}
+
 	type TestSetup struct {
-		apiClient tracetracking.SignedAPIClient
+		startTXM         func(logger.Logger) *txm.Txm
+		txmTestingClient *testingAPIClientWrapped
+		setupClient      tracetracking.SignedAPIClient
 	}
 
 	type testCase struct {
 		name string
 		test func(t *testing.T, setup TestSetup)
 	}
-	logger := test_logger.New()
 	keystore := relayer_utils.NewTestKeystore(t)
 
-	createAndFundAccounts := func() func(count uint) []tracetracking.SignedAPIClient {
+	createAndFundAccounts := func() func(count int) []connection {
 		var setupOnce sync.Once
 		tonChain, err := utils.StartChain(t, chainsel.TON_LOCALNET.Selector, &setupOnce)
 		require.NoError(t, err)
 		keystore.AddKey(tonChain.Wallet.PrivateKey())
 		require.NotNil(t, keystore)
 
-		return func(count uint) []tracetracking.SignedAPIClient {
+		return func(count int) []connection {
 			initialAmount := big.NewInt(10_000_000_000) // 10k TON
 			recipients := make([]*address.Address, count)
 			amounts := make([]tlb.Coins, count)
-			accounts := make([]tracetracking.SignedAPIClient, count)
+			accounts := make([]connection, count)
 
 			for i := range count {
-				w, err := tvm.NewRandomV5R1TestWallet(tonChain.Client, -217)
+				txmClient := &testingAPIClientWrapped{
+					APIClientWrapped: tonChain.Client,
+				}
+				txmWallet, err := tvm.NewRandomV5R1TestWallet(txmClient, networkGlobalID)
 				require.NoError(t, err)
 
-				recipients[i] = w.Address()
+				setupWallet, err := tvm.NewV5R1Wallet(tonChain.Client, networkGlobalID, txmWallet.PrivateKey())
+				require.NoError(t, err)
+
+				recipients[i] = setupWallet.WalletAddress()
 				amounts[i] = tlb.FromNanoTON(initialAmount)
 
-				accounts[i] = tracetracking.NewSignedAPIClient(tonChain.Client, *w)
+				accounts[i] = connection{
+					txmSignedAPIClient: tracetracking.NewSignedAPIClient(txmClient, *txmWallet),
+					txmTestingClient:   txmClient,
+					setupClient:        tracetracking.NewSignedAPIClient(tonChain.Client, *setupWallet),
+				}
 
-				keystore.AddKey(w.PrivateKey())
+				keystore.AddKey(txmWallet.PrivateKey())
 				require.NotNil(t, keystore)
 			}
 
@@ -76,39 +99,22 @@ func TestTxmLocal(t *testing.T) {
 		}
 	}()
 
-	getTxm := func(account tracetracking.SignedAPIClient) *txm.Txm {
-		config := txm.DefaultConfigSet
-		config.ConfirmPollInterval = commonconfig.MustNewDuration(2 * time.Second)
-
-		chainID := string(chainsel.TON_LOCALNET.ChainID)
-
-		signedClientProvider := func(ctx context.Context) (tracetracking.SignedAPIClient, error) {
-			return account, nil
-		}
-		tonTxm, err := txm.New(logger, chainID, keystore, signedClientProvider, config)
-		require.NoError(t, err)
-		err = tonTxm.Start(t.Context())
-		require.NoError(t, err)
-
-		return tonTxm
-	}
-
 	testCases := []testCase{
 		{
 			name: "Counter contract interactions",
 			test: func(t *testing.T, setup TestSetup) {
-				tonTxm := getTxm(setup.apiClient)
-				defer func() {
-					_ = tonTxm.Close()
-				}()
+				lggr := test_logger.New()
+				tonTxm := setup.startTXM(lggr)
+				t.Cleanup(func() { require.NoError(t, tonTxm.Close(), "Fail to close TXM") })
 
 				const iterations int = 5
 				// Deploy counter contract
 				const initialValue uint32 = 0
-				counterAddr := deployCounterContract(t, setup.apiClient.Wallet, initialValue)
+				setup.txmTestingClient.On("SendExternalMessageWaitTransaction", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {})
+				counterAddr := deployCounterContract(t, setup.setupClient.Wallet, initialValue)
 
 				// Check current state
-				current, err := counter.GetValue(t.Context(), setup.apiClient.Client, counterAddr)
+				current, err := counter.GetValue(t.Context(), setup.setupClient.Client, counterAddr)
 				require.NoError(t, err)
 				require.Equal(t, initialValue, current)
 
@@ -121,7 +127,7 @@ func TestTxmLocal(t *testing.T) {
 
 					incErr = tonTxm.Enqueue(txm.Request{
 						Mode:            wallet.PayGasSeparately | wallet.IgnoreErrors,
-						FromWallet:      setup.apiClient.Wallet,
+						FromWallet:      setup.setupClient.Wallet,
 						ContractAddress: *counterAddr,
 						Amount:          tlb.MustFromTON("0.05"),
 						Bounce:          true,
@@ -136,7 +142,7 @@ func TestTxmLocal(t *testing.T) {
 
 					incErr = tonTxm.Enqueue(txm.Request{
 						Mode:            wallet.PayGasSeparately | wallet.IgnoreErrors,
-						FromWallet:      setup.apiClient.Wallet,
+						FromWallet:      setup.setupClient.Wallet,
 						ContractAddress: *counterAddr,
 						Amount:          tlb.MustFromTON("0.05"),
 						Bounce:          true,
@@ -148,37 +154,146 @@ func TestTxmLocal(t *testing.T) {
 				}
 
 				// Wait for all txs
-				waitForStableInflightCount(logger, tonTxm, 30*time.Second)
+				waitForStableInflightCount(lggr, tonTxm, 30*time.Second)
 
 				// Check final value
-				final, err := counter.GetValue(t.Context(), setup.apiClient.Client, counterAddr)
+				final, err := counter.GetValue(t.Context(), setup.setupClient.Client, counterAddr)
 				require.NoError(t, err)
-				logger.Infow("Final counter value", "value", final)
+				lggr.Infow("Final counter value", "value", final)
 				require.Equal(t, expected, final)
-			},
-		},
+			}}, {
+			name: "ZeroBalance",
+			test: func(t *testing.T, setup TestSetup) {
+				lggr := test_logger.New()
+				tonTxm := setup.startTXM(lggr)
+				t.Cleanup(func() { require.NoError(t, tonTxm.Close(), "Fail to close TXM") })
+
+				// Deploy counter contract
+				const initialValue uint32 = 0
+				counterAddr := deployCounterContract(t, setup.setupClient.Wallet, initialValue)
+
+				// Drain the transmitter's balance
+				{
+					msgTrace, err := setup.setupClient.SendAndWaitForTrace(t.Context(), *tvm.ZeroAddress, &wallet.Message{
+						Mode: wallet.IgnoreErrors | wallet.CarryAllRemainingBalance,
+						InternalMessage: &tlb.InternalMessage{
+							DstAddr: tvm.ZeroAddress,
+							Amount:  tlb.MustFromTON("0.1"),
+							Body:    tvm.EmptyCell,
+						},
+					})
+					require.NoError(t, err)
+
+					t.Logf("Drain trace:\n%s", debug.NewDebuggerTreeTrace(nil).DumpReceived(msgTrace))
+
+					tb := balance.MustGet(t, setup.setupClient.Client, setup.setupClient.Wallet.WalletAddress())
+					require.Truef(t, tb.IsZero(), "Transmitter balance should be zero after depletion, but it is %s", tb.String())
+				}
+
+				// Enqueue valid tx which should now fail due to insufficient funds
+				{
+					// Assert that SendWaitTransaction is called only once, which means Txm is not retrying the transaction after the first failure
+					setup.txmTestingClient.On("SendExternalMessageWaitTransaction", mock.Anything, mock.Anything, mock.Anything).
+						Run(func(args mock.Arguments) {
+							ext := args.Get(1).(*tlb.ExternalMessage)
+							t.Logf("Mock SendWaitTransaction called with dstAddr: %s", ext.DstAddr.String())
+						}).Once()
+					incrementBody, incErr := tlb.ToCell(counter.IncreaseCount{QueryID: 1})
+					require.NoError(t, incErr)
+
+					err := tonTxm.Enqueue(txm.Request{
+						Mode:            wallet.PayGasSeparately | wallet.IgnoreErrors,
+						FromWallet:      setup.setupClient.Wallet,
+						ContractAddress: *counterAddr,
+						Amount:          tlb.MustFromTON("0.05"),
+						Bounce:          true,
+						Body:            incrementBody,
+					})
+					require.NoError(t, err)
+
+					waitForStableInflightCount(lggr, tonTxm, 30*time.Second)
+
+					currentValue, err := counter.GetValue(t.Context(), setup.setupClient.Client, counterAddr)
+					require.NoError(t, err)
+					require.Equal(t, initialValue, currentValue, "Counter should remain unchanged after tx with insufficient funds")
+					setup.txmTestingClient.AssertExpectations(t)
+				}
+			}}, {
+			name: "InsufficientBalance",
+			test: func(t *testing.T, setup TestSetup) {
+				// txm should log that wallet didn't output any message
+				lggr, logs := test_logger.NewObserved()
+				tonTxm := setup.startTXM(lggr)
+				t.Cleanup(func() { require.NoError(t, tonTxm.Close(), "Fail to close TXM") })
+
+				// Deploy counter contract
+				const initialValue uint32 = 0
+				counterAddr := deployCounterContract(t, setup.setupClient.Wallet, initialValue)
+
+				// Enqueue valid tx which should now fail due to insufficient funds
+				{
+					amount := balance.MustGet(t, setup.setupClient.Client, setup.setupClient.Wallet.WalletAddress())
+					// Assert that SendWaitTransaction is called only once, which means Txm is not retrying the transaction after the first failure
+					setup.txmTestingClient.On("SendExternalMessageWaitTransaction", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+						ext := args.Get(1).(*tlb.ExternalMessage)
+						t.Logf("Mock SendWaitTransaction called with dstAddr: %s", ext.DstAddr.String())
+					}).Once()
+					incrementBody, incErr := tlb.ToCell(counter.IncreaseCount{QueryID: 1})
+					require.NoError(t, incErr)
+
+					err := tonTxm.Enqueue(txm.Request{
+						Mode:            wallet.PayGasSeparately | wallet.IgnoreErrors,
+						FromWallet:      setup.setupClient.Wallet,
+						ContractAddress: *counterAddr,
+						Amount:          *amount,
+						Bounce:          true,
+						Body:            incrementBody,
+					})
+					require.NoError(t, err)
+
+					waitForStableInflightCount(lggr, tonTxm, 30*time.Second)
+
+					currentValue, err := counter.GetValue(t.Context(), setup.setupClient.Client, counterAddr)
+					require.NoError(t, err)
+					require.Equal(t, initialValue, currentValue, "Counter should remain unchanged after tx with insufficient funds")
+					setup.txmTestingClient.AssertExpectations(t)
+
+					// TODO TXM should enabling getting TX results with error. Testing logs is not reliable. https://smartcontract-it.atlassian.net/browse/NONEVM-4956
+					entries := logs.FilterMessage("transaction did not produce any outgoing messages, this may indicate that the value of the enqueued message was higher than the balance of the account").FilterLevelExact(zapcore.ErrorLevel)
+					require.GreaterOrEqual(t, entries.Len(), 1, "expected TXM to log error")
+				}
+			}},
 	}
 
-	accounts := createAndFundAccounts(10)
-	getAccount := func() tracetracking.SignedAPIClient {
-		require.NotEmpty(t, accounts, "No pre-funded accounts available")
-		acc := accounts[0]
-		accounts = accounts[1:]
-		return acc
-	}
+	accounts := createAndFundAccounts(len(testCases))
 
-	for _, tc := range testCases {
+	for i, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			transmitterAccount := getAccount()
-
 			tc.test(t, TestSetup{
-				apiClient: transmitterAccount,
+				setupClient:      accounts[i].setupClient,
+				txmTestingClient: accounts[i].txmTestingClient,
+				startTXM: func(lggr logger.Logger) *txm.Txm {
+					config := txm.DefaultConfigSet
+					config.ConfirmPollInterval = commonconfig.MustNewDuration(2 * time.Second)
+
+					chainID := string(chainsel.TON_LOCALNET.ChainID)
+
+					signedClientProvider := func(ctx context.Context) (tracetracking.SignedAPIClient, error) {
+						return accounts[i].txmSignedAPIClient, nil
+					}
+					tonTxm, err := txm.New(lggr, chainID, keystore, signedClientProvider, config)
+					require.NoError(t, err)
+					err = tonTxm.Start(t.Context())
+					require.NoError(t, err)
+
+					return tonTxm
+				},
 			})
 		})
 	}
 }
 
-func waitForStableInflightCount(logger logger.Logger, txm *txm.Txm, duration time.Duration) {
+func waitForStableInflightCount(lggr logger.Logger, txm *txm.Txm, duration time.Duration) {
 	const checkInterval = 200 * time.Millisecond
 	stableSince := time.Now()
 	stabilityReached := false
@@ -188,16 +303,16 @@ func waitForStableInflightCount(logger logger.Logger, txm *txm.Txm, duration tim
 
 		if queueLen == 0 && unconfirmedLen == 0 {
 			if !stabilityReached {
-				logger.Debugw("Inflight count stable at zero, starting timer")
+				lggr.Debugw("Inflight count stable at zero, starting timer")
 				stabilityReached = true
 			}
 			if time.Since(stableSince) >= duration {
-				logger.Debugw("Inflight count was stable for full duration", "duration", duration)
+				lggr.Debugw("Inflight count was stable for full duration", "duration", duration)
 				return
 			}
 		} else {
 			if stabilityReached {
-				logger.Warnw("Inflight count was stable but changed", "queueLen", queueLen, "unconfirmedLen", unconfirmedLen, "elapsed", time.Since(stableSince))
+				lggr.Warnw("Inflight count was stable but changed", "queueLen", queueLen, "unconfirmedLen", unconfirmedLen, "elapsed", time.Since(stableSince))
 			}
 			stableSince = time.Now()
 			stabilityReached = false
@@ -227,4 +342,14 @@ func deployCounterContract(t *testing.T, wallet wallet.Wallet, initialValue uint
 	require.NoError(t, err)
 
 	return counterAddr
+}
+
+type testingAPIClientWrapped struct {
+	mock.Mock
+	ton.APIClientWrapped
+}
+
+func (m *testingAPIClientWrapped) SendExternalMessageWaitTransaction(ctx context.Context, ext *tlb.ExternalMessage) (*tlb.Transaction, *ton.BlockIDExt, []byte, error) {
+	m.Called(ctx, ext)
+	return m.APIClientWrapped.SendExternalMessageWaitTransaction(ctx, ext)
 }

--- a/pkg/ton/tracetracking/signed_api_client.go
+++ b/pkg/ton/tracetracking/signed_api_client.go
@@ -3,6 +3,7 @@ package tracetracking
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/xssnick/tonutils-go/address"
@@ -26,6 +27,28 @@ func NewSignedAPIClient(client ton.APIClientWrapped, wallet wallet.Wallet) Signe
 	}
 }
 
+type WalletTXError struct {
+	Err         error
+	Destination address.Address
+}
+
+var (
+	_ error = (*WalletTXError)(nil)
+)
+
+func (e *WalletTXError) Error() string {
+	return fmt.Sprintf("wallet transaction error for destination %s: %v", e.Destination.String(), e.Err)
+}
+
+func (e *WalletTXError) Unwrap() error {
+	return e.Err
+}
+
+func (e *WalletTXError) IsInboundExternalMessageRejectedByAccountError() bool {
+	const errPrefix = "failed to send message: lite server error, code -701"
+	return strings.HasPrefix(e.Err.Error(), errPrefix)
+}
+
 // SendWaitTransaction sends a transaction to the specified address and waits for
 // it to be confirmed on the blockchain. It returns the resulting ReceivedMessage
 // with outgoing messages (if any) and the block sequence number where the
@@ -36,7 +59,7 @@ func NewSignedAPIClient(client ton.APIClientWrapped, wallet wallet.Wallet) Signe
 func (c *SignedAPIClient) SendWaitTransaction(ctx context.Context, dstAddr address.Address, messageToSend *wallet.Message) (*ReceivedMessage, *ton.BlockIDExt, error) {
 	tx, block, err := c.Wallet.SendWaitTransaction(ctx, messageToSend)
 	if err != nil {
-		return nil, nil, fmt.Errorf("deposit transaction failed for %s: %w", dstAddr.String(), err)
+		return nil, nil, &WalletTXError{Err: err, Destination: dstAddr}
 	}
 
 	receivedMessage, err := MapToReceivedMessage(tx)

--- a/pkg/ton/tracetracking/signed_api_client.go
+++ b/pkg/ton/tracetracking/signed_api_client.go
@@ -27,26 +27,9 @@ func NewSignedAPIClient(client ton.APIClientWrapped, wallet wallet.Wallet) Signe
 	}
 }
 
-type WalletTXError struct {
-	Err         error
-	Destination address.Address
-}
-
-var (
-	_ error = (*WalletTXError)(nil)
-)
-
-func (e *WalletTXError) Error() string {
-	return fmt.Sprintf("wallet transaction error for destination %s: %v", e.Destination.String(), e.Err)
-}
-
-func (e *WalletTXError) Unwrap() error {
-	return e.Err
-}
-
-func (e *WalletTXError) IsInboundExternalMessageRejectedByAccountError() bool {
-	const errPrefix = "failed to send message: lite server error, code -701"
-	return strings.HasPrefix(e.Err.Error(), errPrefix)
+func IsInboundExternalMessageRejectedByAccountError(err error) bool {
+	return strings.HasPrefix(err.Error(), "wallet transaction error for destination") &&
+		strings.Contains(err.Error(), "failed to send message: lite server error, code -701")
 }
 
 // SendWaitTransaction sends a transaction to the specified address and waits for
@@ -59,7 +42,7 @@ func (e *WalletTXError) IsInboundExternalMessageRejectedByAccountError() bool {
 func (c *SignedAPIClient) SendWaitTransaction(ctx context.Context, dstAddr address.Address, messageToSend *wallet.Message) (*ReceivedMessage, *ton.BlockIDExt, error) {
 	tx, block, err := c.Wallet.SendWaitTransaction(ctx, messageToSend)
 	if err != nil {
-		return nil, nil, &WalletTXError{Err: err, Destination: dstAddr}
+		return nil, nil, fmt.Errorf("wallet transaction error for destination %s: %w", dstAddr.String(), err)
 	}
 
 	receivedMessage, err := MapToReceivedMessage(tx)

--- a/pkg/ton/tvm/wallet.go
+++ b/pkg/ton/tvm/wallet.go
@@ -2,6 +2,7 @@ package tvm
 
 import (
 	"context"
+	"crypto/ed25519"
 	"errors"
 	"fmt"
 	"math/big"
@@ -40,6 +41,16 @@ func NewRandomV5R1TestWallet(api wallet.TonAPI, networkGlobalID int32) (*wallet.
 	}
 
 	return wallet.FromSeed(api, wallet.NewSeed(), v5r1Config)
+}
+
+// NewV5R1Wallet creates a new V5R1 wallet by using the provided private key.
+func NewV5R1Wallet(api wallet.TonAPI, networkGlobalID int32, privateKey ed25519.PrivateKey) (*wallet.Wallet, error) {
+	v5r1Config := wallet.ConfigV5R1Final{
+		NetworkGlobalID: networkGlobalID,
+		Workchain:       0,
+	}
+
+	return wallet.FromPrivateKey(api, privateKey, v5r1Config)
 }
 
 func NewRandomHighloadV3TestWallet(client ton.APIClientWrapped) (*wallet.Wallet, error) {

--- a/pkg/txm/txm.go
+++ b/pkg/txm/txm.go
@@ -353,18 +353,13 @@ func (t *Txm) broadcastWithRetry(ctx context.Context, tx *Tx, msg *wallet.Messag
 				"to", tx.To.String(),
 				"timeout", t.config.SendTimeout.Duration(),
 				"err", err)
-		} else if werr, ok := func() (e *tracetracking.WalletTXError, ok bool) {
-			e = &tracetracking.WalletTXError{}
-			return e, errors.As(err, &e)
-		}(); ok && werr.IsInboundExternalMessageRejectedByAccountError() {
-			// TODO change the above inline function for errors.AsType when we update to Go 1.26:
-			// } else if err, ok := errors.AsType[tracetracking.WalletTXError{}](err); ok && werr.IsInboundExternalMessageRejectedByAccountError() {
-			err = fmt.Errorf("transaction rejected by TON node, likely due to insufficient balance: %w", werr)
+		} else if tracetracking.IsInboundExternalMessageRejectedByAccountError(err) {
+			err = fmt.Errorf("transaction rejected by TON node, likely due to insufficient balance: %w", err)
 			t.logger.Warnw(err.Error(),
 				"txID", txID,
 				"attempt", attempt,
 				"to", tx.To.String(),
-				"err", werr)
+				"err", err)
 			break
 		} else {
 			t.logger.Warnw("failed to broadcast tx, will retry",

--- a/pkg/txm/txm.go
+++ b/pkg/txm/txm.go
@@ -302,6 +302,7 @@ func (t *Txm) broadcastWithRetry(ctx context.Context, tx *Tx, msg *wallet.Messag
 	}
 
 	// try to broadcast transaction
+retryLoop:
 	for attempt := uint(1); attempt <= t.config.MaxSendRetryAttempts; attempt++ {
 		t.logger.Debugw("sending transaction to TON",
 			"txID", txID,
@@ -346,22 +347,23 @@ func (t *Txm) broadcastWithRetry(ctx context.Context, tx *Tx, msg *wallet.Messag
 		}
 
 		// Transaction failed to broadcast. Log error as a warning for now and fall through to retry delay below.
-		if errors.Is(err, context.DeadlineExceeded) {
+		switch {
+		case errors.Is(err, context.DeadlineExceeded):
 			t.logger.Warnw("broadcast timed out, will retry",
 				"txID", txID,
 				"attempt", attempt,
 				"to", tx.To.String(),
 				"timeout", t.config.SendTimeout.Duration(),
 				"err", err)
-		} else if tracetracking.IsInboundExternalMessageRejectedByAccountError(err) {
+		case tracetracking.IsInboundExternalMessageRejectedByAccountError(err):
 			err = fmt.Errorf("transaction rejected by TON node, likely due to insufficient balance: %w", err)
 			t.logger.Warnw(err.Error(),
 				"txID", txID,
 				"attempt", attempt,
 				"to", tx.To.String(),
 				"err", err)
-			break
-		} else {
+			break retryLoop
+		default:
 			t.logger.Warnw("failed to broadcast tx, will retry",
 				"txID", txID,
 				"attempt", attempt,

--- a/pkg/txm/txm.go
+++ b/pkg/txm/txm.go
@@ -331,6 +331,14 @@ func (t *Txm) broadcastWithRetry(ctx context.Context, tx *Tx, msg *wallet.Messag
 				t.logger.Errorw("transaction failed", "exitcode", exitCode, "description", exitCode.Describe())
 			}
 
+			if len(receivedMessage.OutgoingInternalSentMessages) == 0 && len(receivedMessage.OutgoingInternalReceivedMessages) == 0 {
+				t.logger.Errorw("transaction did not produce any outgoing messages, this may indicate that the value of the enqueued message was higher than the balance of the account",
+					"txID", txID,
+					"to", tx.To.String(),
+					"amount", tx.Amount.Nano().String(),
+				)
+			}
+
 			if *t.config.EnableTraceLogging {
 				t.gatherAndLogTrace(ctx, client, receivedMessage, txID)
 			}
@@ -345,6 +353,19 @@ func (t *Txm) broadcastWithRetry(ctx context.Context, tx *Tx, msg *wallet.Messag
 				"to", tx.To.String(),
 				"timeout", t.config.SendTimeout.Duration(),
 				"err", err)
+		} else if werr, ok := func() (e *tracetracking.WalletTXError, ok bool) {
+			e = &tracetracking.WalletTXError{}
+			return e, errors.As(err, &e)
+		}(); ok && werr.IsInboundExternalMessageRejectedByAccountError() {
+			// TODO change the above inline function for errors.AsType when we update to Go 1.26:
+			// } else if err, ok := errors.AsType[tracetracking.WalletTXError{}](err); ok && werr.IsInboundExternalMessageRejectedByAccountError() {
+			err = fmt.Errorf("transaction rejected by TON node, likely due to insufficient balance: %w", werr)
+			t.logger.Warnw(err.Error(),
+				"txID", txID,
+				"attempt", attempt,
+				"to", tx.To.String(),
+				"err", werr)
+			break
 		} else {
 			t.logger.Warnw("failed to broadcast tx, will retry",
 				"txID", txID,


### PR DESCRIPTION
[NONEVM-4760](https://smartcontract-it.atlassian.net/browse/NONEVM-4760)

Depends on https://github.com/smartcontractkit/chainlink-ton/pull/721

[NONEVM-4760]: https://smartcontract-it.atlassian.net/browse/NONEVM-4760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ