### PR TITLE
Fix/client caching

### DIFF
--- a/integration-tests/chain/chain_test.go
+++ b/integration-tests/chain/chain_test.go
@@ -123,6 +123,50 @@ func TestClientRotation(t *testing.T) {
 	requireAlways(t, txmResolvesHealthyClient, 5*time.Second, 100*time.Millisecond)
 }
 
+// Verify that cached ConnectionPool can recover from a broken connection
+func TestHealsFromBrokenConnection(t *testing.T) {
+	var unstableRPC *proxy.Proxy
+
+	tonChain, _ := setupChain(t, nil, func(chainURL string) config.Nodes {
+		unstableRPC = proxy.New(t, chainURL, proxy.BehaviourEnabled)
+
+		return config.Nodes{
+			{
+				Name: new("unstable-rpc"),
+				URL:  commonconfig.MustParseURL(unstableRPC.URL()),
+			},
+		}
+	})
+
+	// Should give us a client based on the healthy RPC (rpcA)
+	// wait for the initial client to be created
+	txmClientProvider := func(ctx context.Context) (ton.APIClientWrapped, error) {
+		signed, err := tonChain.TxManager().GetClient(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return signed.Client, nil
+	}
+
+	clientTime := time.Now()
+	require.Eventually(t, getClient(t, txmClientProvider, requireHealthyClient), 5*time.Second, 200*time.Millisecond)
+
+	// Now disconnect unstableRPC while keeping its listener alive, so the same
+	// endpoint can later recover.
+	unstableRPC.SetBehaviour(proxy.BehaviourDisconnected)
+	unstableRPC.DropConnections()
+
+	// relay.Chain will keep giving us a client based on the unstable RPC, which is now broken
+	require.Eventually(t, getClient(t, tonChain.GetClient, requireUnhealthyClient), 5*time.Second, 200*time.Millisecond)
+	require.Less(t, time.Since(clientTime), ClientTTL, "Client should have been cached and not expired yet")
+
+	// Now enable unstableRPC again, which should enable getClient to return a healthy client again
+	unstableRPC.SetBehaviour(proxy.BehaviourEnabled)
+
+	// relay.Chain should now give us a client based on the healthy RPC (unstableRPC)
+	require.Eventually(t, getClient(t, tonChain.GetClient, requireHealthyClient), 2*ClientTTL+relay.ConnectionTimeout, 2*time.Second)
+}
+
 func TestDontStallOnConnection(t *testing.T) {
 	// The log poller persists its resume checkpoint and ingested logs, so it
 	// needs a real DataSource with the log poller tables created.

--- a/integration-tests/chain/chain_test.go
+++ b/integration-tests/chain/chain_test.go
@@ -36,239 +36,246 @@ import (
 
 const ClientTTL = 30 * time.Second
 
-// setupChain sets up a TON chain and a relay.Chain for testing, returning both.
-//
-// ds can be nil, in which case the relay.Chain will be created without a DataSource. Logpoller will fail to perform any database operations
-func setupChain(t *testing.T, ds sqlutil.DataSource, nodes func(string) config.Nodes) (relay.Chain, cldf_ton.Chain) {
-	lggr := logger.Test(t)
-
+func TestChain(t *testing.T) {
 	var setupOnce sync.Once
 	tonChain, err := test_utils.StartChain(t, chainsel.TON_LOCALNET.Selector, &setupOnce)
 	require.NoError(t, err)
 
-	keystore := relayer_utils.NewTestKeystore(t)
-	keystore.AddKey(tonChain.Wallet.PrivateKey())
+	// setupChain sets up a TON chain and a relay.Chain for testing, returning both.
+	//
+	// ds can be nil, in which case the relay.Chain will be created without a DataSource. Logpoller will fail to perform any database operations
+	setupChain := func(ds sqlutil.DataSource, nodes func(string) config.Nodes) (relay.Chain, cldf_ton.Chain) {
+		lggr := logger.Test(t)
 
-	chainConfig := config.DefaultConfigSet
-	chainConfig.ClientTTL = ClientTTL
+		keystore := relayer_utils.NewTestKeystore(t)
+		keystore.AddKey(tonChain.Wallet.PrivateKey())
 
-	// PollPeriod doubles as the per-iteration timeout (see service.go), so it must
-	// be large enough for a full poll (connect + load + resolve + save) to finish.
-	chainConfig.LogPoller.PollPeriod = commonconfig.MustNewDuration(5 * time.Second)
+		chainConfig := config.DefaultConfigSet
+		chainConfig.ClientTTL = ClientTTL
 
-	tonRelayChain, err := relay.NewChain(&config.TOMLConfig{
-		Enabled:     new(true),
-		ChainID:     strconv.FormatInt(int64(chainsel.TON_LOCALNET.ChainID), 10),
-		NetworkName: chainsel.TON_LOCALNET.Name,
-		Chain:       chainConfig,
-		Nodes:       nodes(tonChain.URL),
-	}, relay.ChainOpts{
-		Logger:   lggr,
-		KeyStore: keystore,
-		DS:       ds,
-	})
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = tonRelayChain.Close() })
-	return tonRelayChain, tonChain
-}
+		// PollPeriod doubles as the per-iteration timeout (see service.go), so it must
+		// be large enough for a full poll (connect + load + resolve + save) to finish.
+		chainConfig.LogPoller.PollPeriod = commonconfig.MustNewDuration(5 * time.Second)
 
-// Verify that relay.NewChain can be called with a broken RPC and that it does not block service initialization.
-// Verify that context is not canceled.
-func TestServiceInitializationIsNotBlockedByBrokenRPC(t *testing.T) {
-	var disconnectedRPC *proxy.Proxy
-
-	setupChain(t, nil, func(chainURL string) config.Nodes {
-		disconnectedRPC = proxy.New(t, chainURL, proxy.BehaviourDisconnected)
-
-		return config.Nodes{
-			{
-				Name: new("disconnected-rpc"),
-				URL:  commonconfig.MustParseURL(disconnectedRPC.URL()),
-			},
-		}
-	})
-}
-
-func TestClientRotation(t *testing.T) {
-	var initiallyHealthyRPC, initiallyDisconnectedRPC *proxy.Proxy
-
-	tonChain, _ := setupChain(t, nil, func(chainURL string) config.Nodes {
-		initiallyHealthyRPC = proxy.New(t, chainURL, proxy.BehaviourEnabled)
-		initiallyDisconnectedRPC = proxy.New(t, chainURL, proxy.BehaviourDisconnected)
-
-		return config.Nodes{
-			{
-				Name: new("initially-healthy-rpc"),
-				URL:  commonconfig.MustParseURL(initiallyHealthyRPC.URL()),
-			},
-			{
-				Name: new("initially-disconnected-rpc"),
-				URL:  commonconfig.MustParseURL(initiallyDisconnectedRPC.URL()),
-			},
-		}
-	})
-
-	// Should give us a client based on the healthy RPC (rpcA)
-	// wait for the initial client to be created
-	txmClientProvider := func(ctx context.Context) (ton.APIClientWrapped, error) {
-		signed, err := tonChain.TxManager().GetClient(ctx)
-		if err != nil {
-			return nil, err
-		}
-		return signed.Client, nil
+		tonRelayChain, err := relay.NewChain(&config.TOMLConfig{
+			Enabled:     new(true),
+			ChainID:     strconv.FormatInt(int64(chainsel.TON_LOCALNET.ChainID), 10),
+			NetworkName: chainsel.TON_LOCALNET.Name,
+			Chain:       chainConfig,
+			Nodes:       nodes(tonChain.URL),
+		}, relay.ChainOpts{
+			Logger:   lggr,
+			KeyStore: keystore,
+			DS:       ds,
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = tonRelayChain.Close() })
+		return tonRelayChain, tonChain
 	}
 
-	txmResolvesHealthyClient := getClient(t, txmClientProvider, requireHealthyClient)
-	require.Eventually(t, txmResolvesHealthyClient, relay.ConnectionTimeout*2, 100*time.Millisecond)
-	// Once we get a healthy client for the first time, we should get it every time. Checking multiple times due to round robin.
-	requireAlways(t, txmResolvesHealthyClient, 5*time.Second, 100*time.Millisecond)
+	t.Run("TestServiceInitializationIsNotBlockedByBrokenRPC", func(t *testing.T) {
+		t.Parallel()
+		// Verify that relay.NewChain can be called with a broken RPC and that it does not block service initialization.
+		// Verify that context is not canceled.
 
-	// Disable initiallyHealthyRPC and expect the client to become unhealthy
-	initiallyHealthyRPC.Close()
-	require.Eventually(t, getClient(t, tonChain.GetClient, requireUnhealthyClient), 5*time.Second, 100*time.Millisecond)
+		var disconnectedRPC *proxy.Proxy
 
-	// Now enable initiallyDisconnectedRPC which should cause the relay to switch to initiallyDisconnectedRPC
-	initiallyDisconnectedRPC.SetBehaviour(proxy.BehaviourEnabled)
+		setupChain(nil, func(chainURL string) config.Nodes {
+			disconnectedRPC = proxy.New(t, chainURL, proxy.BehaviourDisconnected)
 
-	time.Sleep(ClientTTL) // Wait for the cached client to expire, which should cause the relay to switch to initiallyDisconnectedRPC
-
-	// relay.Chain gives us a client connected to initiallyDisconnectedRPC after cached client expires
-	require.Eventually(t, getClient(t, tonChain.GetClient, requireHealthyClient), relay.ConnectionTimeout*2, 100*time.Millisecond)
-	requireAlways(t, getClient(t, tonChain.GetClient, requireHealthyClient), 5*time.Second, 100*time.Millisecond)
-
-	// TXM should have also switched to initiallyDisconnectedRPC
-	requireAlways(t, txmResolvesHealthyClient, 5*time.Second, 100*time.Millisecond)
-}
-
-// Verify that cached ConnectionPool can recover from a broken connection
-func TestHealsFromBrokenConnection(t *testing.T) {
-	var unstableRPC *proxy.Proxy
-
-	tonChain, _ := setupChain(t, nil, func(chainURL string) config.Nodes {
-		unstableRPC = proxy.New(t, chainURL, proxy.BehaviourEnabled)
-
-		return config.Nodes{
-			{
-				Name: new("unstable-rpc"),
-				URL:  commonconfig.MustParseURL(unstableRPC.URL()),
-			},
-		}
+			return config.Nodes{
+				{
+					Name: new("disconnected-rpc"),
+					URL:  commonconfig.MustParseURL(disconnectedRPC.URL()),
+				},
+			}
+		})
 	})
 
-	// Should give us a client based on the healthy RPC (rpcA)
-	// wait for the initial client to be created
-	txmClientProvider := func(ctx context.Context) (ton.APIClientWrapped, error) {
-		signed, err := tonChain.TxManager().GetClient(ctx)
-		if err != nil {
-			return nil, err
+	t.Run("TestClientRotation", func(t *testing.T) {
+		t.Parallel()
+		var initiallyHealthyRPC, initiallyDisconnectedRPC *proxy.Proxy
+
+		tonChain, _ := setupChain(nil, func(chainURL string) config.Nodes {
+			initiallyHealthyRPC = proxy.New(t, chainURL, proxy.BehaviourEnabled)
+			initiallyDisconnectedRPC = proxy.New(t, chainURL, proxy.BehaviourDisconnected)
+
+			return config.Nodes{
+				{
+					Name: new("initially-healthy-rpc"),
+					URL:  commonconfig.MustParseURL(initiallyHealthyRPC.URL()),
+				},
+				{
+					Name: new("initially-disconnected-rpc"),
+					URL:  commonconfig.MustParseURL(initiallyDisconnectedRPC.URL()),
+				},
+			}
+		})
+
+		// Should give us a client based on the healthy RPC (rpcA)
+		// wait for the initial client to be created
+		txmClientProvider := func(ctx context.Context) (ton.APIClientWrapped, error) {
+			signed, err := tonChain.TxManager().GetClient(ctx)
+			if err != nil {
+				return nil, err
+			}
+			return signed.Client, nil
 		}
-		return signed.Client, nil
-	}
 
-	clientTime := time.Now()
-	require.Eventually(t, getClient(t, txmClientProvider, requireHealthyClient), 5*time.Second, 200*time.Millisecond)
+		txmResolvesHealthyClient := getClient(t, txmClientProvider, requireHealthyClient)
+		require.Eventually(t, txmResolvesHealthyClient, relay.ConnectionTimeout*2, 100*time.Millisecond)
+		// Once we get a healthy client for the first time, we should get it every time. Checking multiple times due to round robin.
+		requireAlways(t, txmResolvesHealthyClient, 5*time.Second, 100*time.Millisecond)
 
-	// Now disconnect unstableRPC while keeping its listener alive, so the same
-	// endpoint can later recover.
-	unstableRPC.SetBehaviour(proxy.BehaviourDisconnected)
-	unstableRPC.DropConnections()
+		// Disable initiallyHealthyRPC and expect the client to become unhealthy
+		initiallyHealthyRPC.Close()
+		require.Eventually(t, getClient(t, tonChain.GetClient, requireUnhealthyClient), 5*time.Second, 100*time.Millisecond)
 
-	// relay.Chain will keep giving us a client based on the unstable RPC, which is now broken
-	require.Eventually(t, getClient(t, tonChain.GetClient, requireUnhealthyClient), 5*time.Second, 200*time.Millisecond)
-	require.Less(t, time.Since(clientTime), ClientTTL, "Client should have been cached and not expired yet")
+		// Now enable initiallyDisconnectedRPC which should cause the relay to switch to initiallyDisconnectedRPC
+		initiallyDisconnectedRPC.SetBehaviour(proxy.BehaviourEnabled)
 
-	// Now enable unstableRPC again, which should enable getClient to return a healthy client again
-	unstableRPC.SetBehaviour(proxy.BehaviourEnabled)
+		time.Sleep(ClientTTL) // Wait for the cached client to expire, which should cause the relay to switch to initiallyDisconnectedRPC
 
-	// relay.Chain should now give us a client based on the healthy RPC (unstableRPC)
-	require.Eventually(t, getClient(t, tonChain.GetClient, requireHealthyClient), 2*ClientTTL+relay.ConnectionTimeout, 2*time.Second)
-}
+		// relay.Chain gives us a client connected to initiallyDisconnectedRPC after cached client expires
+		require.Eventually(t, getClient(t, tonChain.GetClient, requireHealthyClient), relay.ConnectionTimeout*2, 100*time.Millisecond)
+		requireAlways(t, getClient(t, tonChain.GetClient, requireHealthyClient), 5*time.Second, 100*time.Millisecond)
 
-func TestDontStallOnConnection(t *testing.T) {
-	// The log poller persists its resume checkpoint and ingested logs, so it
-	// needs a real DataSource with the log poller tables created.
-	ds := pgtest.SetupTestDB(t)
-	require.NoError(t, pgtest.ExecuteSQL(t.Context(), ds, testdata.CreateLogPollerTables))
-
-	// Two RPCs, both initially unusable: stalled-rpc accepts the TCP connection
-	// but never finishes the ADNL handshake; unstable-rpc refuses connections.
-	// The bug: the poller wedges forever on stalled-rpc's handshake and never
-	// rotates, so enabling unstable-rpc below never helps. With a connection
-	// timeout the poller gives up on stalled-rpc and rotates to unstable-rpc.
-	var unstableRPC *proxy.Proxy
-	relayChain, tonChain := setupChain(t, ds, func(chainURL string) config.Nodes {
-		stalledRPC := proxy.New(t, chainURL, proxy.BehaviourStall)
-		unstableRPC = proxy.New(t, chainURL, proxy.BehaviourDisconnected)
-		return config.Nodes{
-			{
-				Name: new("stalled-rpc"),
-				URL:  commonconfig.MustParseURL(stalledRPC.URL()),
-			},
-			{
-				Name: new("unstable-rpc"),
-				URL:  commonconfig.MustParseURL(unstableRPC.URL()),
-			},
-		}
+		// TXM should have also switched to initiallyDisconnectedRPC
+		requireAlways(t, txmResolvesHealthyClient, 5*time.Second, 100*time.Millisecond)
 	})
 
-	// Deploy an event-emitting contract using the chain's direct, always-healthy
-	// client. The emitter must work regardless of the poller's RPC state.
-	sender, err := tvm.NewRandomHighloadV3TestWallet(tonChain.Client)
-	require.NoError(t, err)
-	require.NoError(t, test_utils.FundWallets(
-		t, tonChain.Client,
-		[]*address.Address{sender.Address()},
-		[]tlb.Coins{tlb.MustFromTON("1000")},
-	))
-	emitter, err := helper.NewTestEventSource(t.Context(), tonChain.Client, sender, "emitter", rand.Uint32(), logger.Test(t))
-	require.NoError(t, err)
+	// Verify that cached ConnectionPool can recover from a broken connection
+	t.Run("TestHealsFromBrokenConnection", func(t *testing.T) {
+		t.Parallel()
+		var unstableRPC *proxy.Proxy
 
-	// Register a filter for the emitter's events on the poller, whose RPCs are
-	// both currently unusable.
-	lp := relayChain.LogPoller()
-	_, err = lp.RegisterFilter(t.Context(), models.Filter{
-		Name:     "emitter",
-		Address:  emitter.ContractAddress(),
-		MsgType:  tlb.MsgTypeExternalOut,
-		EventSig: counter.TopicCountIncreased,
-	})
-	require.NoError(t, err)
+		tonChain, _ := setupChain(nil, func(chainURL string) config.Nodes {
+			unstableRPC = proxy.New(t, chainURL, proxy.BehaviourEnabled)
 
-	require.NoError(t, lp.Start(t.Context()))
-	t.Cleanup(func() { _ = lp.Close() })
+			return config.Nodes{
+				{
+					Name: new("unstable-rpc"),
+					URL:  commonconfig.MustParseURL(unstableRPC.URL()),
+				},
+			}
+		})
 
-	// Give the poller time to attempt (and, with the fix, time out on) the stalled
-	// RPC before the other one recovers. With the bug the first attempt wedges the
-	// run loop forever, so enabling unstable-rpc never helps.
-	time.Sleep(2 * time.Second)
-
-	// unstable-rpc recovers; the poller must rotate to it past the stalled one.
-	t.Log("Enabling unstable-rpc; poller must rotate to it past the stalled RPC")
-	unstableRPC.SetBehaviour(proxy.BehaviourEnabled)
-
-	// Emit a known number of events through the direct client.
-	const targetCounter = 3
-	evctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
-	defer cancel()
-	require.NoError(t, emitter.Start(evctx, time.Second, big.NewInt(targetCounter)))
-	t.Cleanup(func() { _ = emitter.Wait() })
-
-	// The proof that the poller recovered is behavioral: it ingests every event
-	// emitted after the RPC became healthy. Had it permanently stalled on the
-	// first connection (the bug), it would never ingest anything.
-	require.Eventually(t, func() bool {
-		logs, _, _, qerr := lp.NewQuery().
-			WithSource(emitter.ContractAddress()).
-			WithEventSig(counter.TopicCountIncreased).
-			Execute(t.Context())
-		if qerr != nil {
-			t.Logf("query failed, retrying: %v", qerr)
-			return false
+		// Should give us a client based on the healthy RPC (rpcA)
+		// wait for the initial client to be created
+		txmClientProvider := func(ctx context.Context) (ton.APIClientWrapped, error) {
+			signed, err := tonChain.TxManager().GetClient(ctx)
+			if err != nil {
+				return nil, err
+			}
+			return signed.Client, nil
 		}
-		t.Logf("poller ingested %d/%d events", len(logs), targetCounter)
-		return len(logs) >= targetCounter
-	}, 120*time.Second, 2*time.Second,
-		"log poller never ingested the emitted events after the RPC recovered")
+
+		clientTime := time.Now()
+		require.Eventually(t, getClient(t, txmClientProvider, requireHealthyClient), 5*time.Second, 200*time.Millisecond)
+
+		// Now disconnect unstableRPC while keeping its listener alive, so the same
+		// endpoint can later recover.
+		unstableRPC.SetBehaviour(proxy.BehaviourDisconnected)
+		unstableRPC.DropConnections()
+
+		// relay.Chain will keep giving us a client based on the unstable RPC, which is now broken
+		require.Eventually(t, getClient(t, tonChain.GetClient, requireUnhealthyClient), 5*time.Second, 200*time.Millisecond)
+		require.Less(t, time.Since(clientTime), ClientTTL, "Client should have been cached and not expired yet")
+
+		// Now enable unstableRPC again, which should enable getClient to return a healthy client again
+		unstableRPC.SetBehaviour(proxy.BehaviourEnabled)
+
+		// relay.Chain should now give us a client based on the healthy RPC (unstableRPC)
+		require.Eventually(t, getClient(t, tonChain.GetClient, requireHealthyClient), 2*ClientTTL+relay.ConnectionTimeout, 2*time.Second)
+	})
+
+	t.Run("TestDontStallOnConnection", func(t *testing.T) {
+		t.Parallel()
+		// The log poller persists its resume checkpoint and ingested logs, so it
+		// needs a real DataSource with the log poller tables created.
+		ds := pgtest.SetupTestDB(t)
+		require.NoError(t, pgtest.ExecuteSQL(t.Context(), ds, testdata.CreateLogPollerTables))
+
+		// Two RPCs, both initially unusable: stalled-rpc accepts the TCP connection
+		// but never finishes the ADNL handshake; unstable-rpc refuses connections.
+		// The bug: the poller wedges forever on stalled-rpc's handshake and never
+		// rotates, so enabling unstable-rpc below never helps. With a connection
+		// timeout the poller gives up on stalled-rpc and rotates to unstable-rpc.
+		var unstableRPC *proxy.Proxy
+		relayChain, tonChain := setupChain(ds, func(chainURL string) config.Nodes {
+			stalledRPC := proxy.New(t, chainURL, proxy.BehaviourStall)
+			unstableRPC = proxy.New(t, chainURL, proxy.BehaviourDisconnected)
+			return config.Nodes{
+				{
+					Name: new("stalled-rpc"),
+					URL:  commonconfig.MustParseURL(stalledRPC.URL()),
+				},
+				{
+					Name: new("unstable-rpc"),
+					URL:  commonconfig.MustParseURL(unstableRPC.URL()),
+				},
+			}
+		})
+
+		// Deploy an event-emitting contract using the chain's direct, always-healthy
+		// client. The emitter must work regardless of the poller's RPC state.
+		sender, err := tvm.NewRandomHighloadV3TestWallet(tonChain.Client)
+		require.NoError(t, err)
+		require.NoError(t, test_utils.FundWallets(
+			t, tonChain.Client,
+			[]*address.Address{sender.Address()},
+			[]tlb.Coins{tlb.MustFromTON("1000")},
+		))
+		emitter, err := helper.NewTestEventSource(t.Context(), tonChain.Client, sender, "emitter", rand.Uint32(), logger.Test(t))
+		require.NoError(t, err)
+
+		// Register a filter for the emitter's events on the poller, whose RPCs are
+		// both currently unusable.
+		lp := relayChain.LogPoller()
+		_, err = lp.RegisterFilter(t.Context(), models.Filter{
+			Name:     "emitter",
+			Address:  emitter.ContractAddress(),
+			MsgType:  tlb.MsgTypeExternalOut,
+			EventSig: counter.TopicCountIncreased,
+		})
+		require.NoError(t, err)
+
+		require.NoError(t, lp.Start(t.Context()))
+		t.Cleanup(func() { _ = lp.Close() })
+
+		// Give the poller time to attempt (and, with the fix, time out on) the stalled
+		// RPC before the other one recovers. With the bug the first attempt wedges the
+		// run loop forever, so enabling unstable-rpc never helps.
+		time.Sleep(2 * time.Second)
+
+		// unstable-rpc recovers; the poller must rotate to it past the stalled one.
+		t.Log("Enabling unstable-rpc; poller must rotate to it past the stalled RPC")
+		unstableRPC.SetBehaviour(proxy.BehaviourEnabled)
+
+		// Emit a known number of events through the direct client.
+		const targetCounter = 3
+		evctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+		defer cancel()
+		require.NoError(t, emitter.Start(evctx, time.Second, big.NewInt(targetCounter)))
+		t.Cleanup(func() { _ = emitter.Wait() })
+
+		// The proof that the poller recovered is behavioral: it ingests every event
+		// emitted after the RPC became healthy. Had it permanently stalled on the
+		// first connection (the bug), it would never ingest anything.
+		require.Eventually(t, func() bool {
+			logs, _, _, qerr := lp.NewQuery().
+				WithSource(emitter.ContractAddress()).
+				WithEventSig(counter.TopicCountIncreased).
+				Execute(t.Context())
+			if qerr != nil {
+				t.Logf("query failed, retrying: %v", qerr)
+				return false
+			}
+			t.Logf("poller ingested %d/%d events", len(logs), targetCounter)
+			return len(logs) >= targetCounter
+		}, 120*time.Second, 2*time.Second,
+			"log poller never ingested the emitted events after the RPC recovered")
+	})
 }
 
 func getClient(

--- a/integration-tests/chain/chain_test.go
+++ b/integration-tests/chain/chain_test.go
@@ -2,6 +2,8 @@ package chain
 
 import (
 	"context"
+	"math/big"
+	"math/rand/v2"
 	"strconv"
 	"sync"
 	"testing"
@@ -9,6 +11,8 @@ import (
 
 	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
+	"github.com/xssnick/tonutils-go/address"
+	"github.com/xssnick/tonutils-go/tlb"
 	"github.com/xssnick/tonutils-go/ton"
 
 	cldf_ton "github.com/smartcontractkit/chainlink-deployments-framework/chain/ton"
@@ -18,10 +22,16 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 
 	test_utils "github.com/smartcontractkit/chainlink-ton/deployment/utils"
+	"github.com/smartcontractkit/chainlink-ton/integration-tests/logpoller/testdata"
+	"github.com/smartcontractkit/chainlink-ton/integration-tests/smoke/logpoller/helper"
+	pgtest "github.com/smartcontractkit/chainlink-ton/integration-tests/testutils/postgres"
 	"github.com/smartcontractkit/chainlink-ton/integration-tests/testutils/proxy"
+	"github.com/smartcontractkit/chainlink-ton/pkg/bindings/examples/counter"
 	"github.com/smartcontractkit/chainlink-ton/pkg/config"
+	"github.com/smartcontractkit/chainlink-ton/pkg/logpoller/models"
 	"github.com/smartcontractkit/chainlink-ton/pkg/relay"
 	relayer_utils "github.com/smartcontractkit/chainlink-ton/pkg/relay/testutils"
+	"github.com/smartcontractkit/chainlink-ton/pkg/ton/tvm"
 )
 
 const ClientTTL = 30 * time.Second
@@ -111,6 +121,93 @@ func TestClientRotation(t *testing.T) {
 
 	// TXM should have also switched to initiallyDisconnectedRPC
 	requireAlways(t, txmResolvesHealthyClient, 5*time.Second, 100*time.Millisecond)
+}
+
+func TestDontStallOnConnection(t *testing.T) {
+	// The log poller persists its resume checkpoint and ingested logs, so it
+	// needs a real DataSource with the log poller tables created.
+	ds := pgtest.SetupTestDB(t)
+	require.NoError(t, pgtest.ExecuteSQL(t.Context(), ds, testdata.CreateLogPollerTables))
+
+	// Two RPCs, both initially unusable: stalled-rpc accepts the TCP connection
+	// but never finishes the ADNL handshake; unstable-rpc refuses connections.
+	// The bug: the poller wedges forever on stalled-rpc's handshake and never
+	// rotates, so enabling unstable-rpc below never helps. With a connection
+	// timeout the poller gives up on stalled-rpc and rotates to unstable-rpc.
+	var unstableRPC *proxy.Proxy
+	relayChain, tonChain := setupChain(t, ds, func(chainURL string) config.Nodes {
+		stalledRPC := proxy.New(t, chainURL, proxy.BehaviourStall)
+		unstableRPC = proxy.New(t, chainURL, proxy.BehaviourDisconnected)
+		return config.Nodes{
+			{
+				Name: new("stalled-rpc"),
+				URL:  commonconfig.MustParseURL(stalledRPC.URL()),
+			},
+			{
+				Name: new("unstable-rpc"),
+				URL:  commonconfig.MustParseURL(unstableRPC.URL()),
+			},
+		}
+	})
+
+	// Deploy an event-emitting contract using the chain's direct, always-healthy
+	// client. The emitter must work regardless of the poller's RPC state.
+	sender, err := tvm.NewRandomHighloadV3TestWallet(tonChain.Client)
+	require.NoError(t, err)
+	require.NoError(t, test_utils.FundWallets(
+		t, tonChain.Client,
+		[]*address.Address{sender.Address()},
+		[]tlb.Coins{tlb.MustFromTON("1000")},
+	))
+	emitter, err := helper.NewTestEventSource(t.Context(), tonChain.Client, sender, "emitter", rand.Uint32(), logger.Test(t))
+	require.NoError(t, err)
+
+	// Register a filter for the emitter's events on the poller, whose RPCs are
+	// both currently unusable.
+	lp := relayChain.LogPoller()
+	_, err = lp.RegisterFilter(t.Context(), models.Filter{
+		Name:     "emitter",
+		Address:  emitter.ContractAddress(),
+		MsgType:  tlb.MsgTypeExternalOut,
+		EventSig: counter.TopicCountIncreased,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, lp.Start(t.Context()))
+	t.Cleanup(func() { _ = lp.Close() })
+
+	// Give the poller time to attempt (and, with the fix, time out on) the stalled
+	// RPC before the other one recovers. With the bug the first attempt wedges the
+	// run loop forever, so enabling unstable-rpc never helps.
+	time.Sleep(2 * time.Second)
+
+	// unstable-rpc recovers; the poller must rotate to it past the stalled one.
+	t.Log("Enabling unstable-rpc; poller must rotate to it past the stalled RPC")
+	unstableRPC.SetBehaviour(proxy.BehaviourEnabled)
+
+	// Emit a known number of events through the direct client.
+	const targetCounter = 3
+	evctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+	defer cancel()
+	require.NoError(t, emitter.Start(evctx, time.Second, big.NewInt(targetCounter)))
+	t.Cleanup(func() { _ = emitter.Wait() })
+
+	// The proof that the poller recovered is behavioral: it ingests every event
+	// emitted after the RPC became healthy. Had it permanently stalled on the
+	// first connection (the bug), it would never ingest anything.
+	require.Eventually(t, func() bool {
+		logs, _, _, qerr := lp.NewQuery().
+			WithSource(emitter.ContractAddress()).
+			WithEventSig(counter.TopicCountIncreased).
+			Execute(t.Context())
+		if qerr != nil {
+			t.Logf("query failed, retrying: %v", qerr)
+			return false
+		}
+		t.Logf("poller ingested %d/%d events", len(logs), targetCounter)
+		return len(logs) >= targetCounter
+	}, 120*time.Second, 2*time.Second,
+		"log poller never ingested the emitted events after the RPC recovered")
 }
 
 func getClient(

--- a/integration-tests/chain/chain_test.go
+++ b/integration-tests/chain/chain_test.go
@@ -72,6 +72,23 @@ func setupChain(t *testing.T, ds sqlutil.DataSource, nodes func(string) config.N
 	return tonRelayChain, tonChain
 }
 
+// Verify that relay.NewChain can be called with a broken RPC and that it does not block service initialization.
+// Verify that context is not canceled.
+func TestServiceInitializationIsNotBlockedByBrokenRPC(t *testing.T) {
+	var disconnectedRPC *proxy.Proxy
+
+	setupChain(t, nil, func(chainURL string) config.Nodes {
+		disconnectedRPC = proxy.New(t, chainURL, proxy.BehaviourDisconnected)
+
+		return config.Nodes{
+			{
+				Name: new("disconnected-rpc"),
+				URL:  commonconfig.MustParseURL(disconnectedRPC.URL()),
+			},
+		}
+	})
+}
+
 func TestClientRotation(t *testing.T) {
 	var initiallyHealthyRPC, initiallyDisconnectedRPC *proxy.Proxy
 

--- a/integration-tests/chain/chain_test.go
+++ b/integration-tests/chain/chain_test.go
@@ -102,7 +102,7 @@ func TestClientRotation(t *testing.T) {
 	}
 
 	txmResolvesHealthyClient := getClient(t, txmClientProvider, requireHealthyClient)
-	require.Eventually(t, txmResolvesHealthyClient, 5*time.Second, 100*time.Millisecond)
+	require.Eventually(t, txmResolvesHealthyClient, relay.ConnectionTimeout*2, 100*time.Millisecond)
 	// Once we get a healthy client for the first time, we should get it every time. Checking multiple times due to round robin.
 	requireAlways(t, txmResolvesHealthyClient, 5*time.Second, 100*time.Millisecond)
 
@@ -116,7 +116,7 @@ func TestClientRotation(t *testing.T) {
 	time.Sleep(ClientTTL) // Wait for the cached client to expire, which should cause the relay to switch to initiallyDisconnectedRPC
 
 	// relay.Chain gives us a client connected to initiallyDisconnectedRPC after cached client expires
-	require.Eventually(t, getClient(t, tonChain.GetClient, requireHealthyClient), 5*time.Second, 100*time.Millisecond)
+	require.Eventually(t, getClient(t, tonChain.GetClient, requireHealthyClient), relay.ConnectionTimeout*2, 100*time.Millisecond)
 	requireAlways(t, getClient(t, tonChain.GetClient, requireHealthyClient), 5*time.Second, 100*time.Millisecond)
 
 	// TXM should have also switched to initiallyDisconnectedRPC

--- a/integration-tests/chain/chain_test.go
+++ b/integration-tests/chain/chain_test.go
@@ -1,0 +1,175 @@
+package chain
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	chainsel "github.com/smartcontractkit/chain-selectors"
+	"github.com/stretchr/testify/require"
+	"github.com/xssnick/tonutils-go/ton"
+
+	cldf_ton "github.com/smartcontractkit/chainlink-deployments-framework/chain/ton"
+
+	commonconfig "github.com/smartcontractkit/chainlink-common/pkg/config"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
+
+	test_utils "github.com/smartcontractkit/chainlink-ton/deployment/utils"
+	"github.com/smartcontractkit/chainlink-ton/integration-tests/testutils/proxy"
+	"github.com/smartcontractkit/chainlink-ton/pkg/config"
+	"github.com/smartcontractkit/chainlink-ton/pkg/relay"
+	relayer_utils "github.com/smartcontractkit/chainlink-ton/pkg/relay/testutils"
+)
+
+const ClientTTL = 30 * time.Second
+
+// setupChain sets up a TON chain and a relay.Chain for testing, returning both.
+//
+// ds can be nil, in which case the relay.Chain will be created without a DataSource. Logpoller will fail to perform any database operations
+func setupChain(t *testing.T, ds sqlutil.DataSource, nodes func(string) config.Nodes) (relay.Chain, cldf_ton.Chain) {
+	lggr := logger.Test(t)
+
+	var setupOnce sync.Once
+	tonChain, err := test_utils.StartChain(t, chainsel.TON_LOCALNET.Selector, &setupOnce)
+	require.NoError(t, err)
+
+	keystore := relayer_utils.NewTestKeystore(t)
+	keystore.AddKey(tonChain.Wallet.PrivateKey())
+
+	chainConfig := config.DefaultConfigSet
+	chainConfig.ClientTTL = ClientTTL
+
+	// PollPeriod doubles as the per-iteration timeout (see service.go), so it must
+	// be large enough for a full poll (connect + load + resolve + save) to finish.
+	chainConfig.LogPoller.PollPeriod = commonconfig.MustNewDuration(5 * time.Second)
+
+	tonRelayChain, err := relay.NewChain(&config.TOMLConfig{
+		Enabled:     new(true),
+		ChainID:     strconv.FormatInt(int64(chainsel.TON_LOCALNET.ChainID), 10),
+		NetworkName: chainsel.TON_LOCALNET.Name,
+		Chain:       chainConfig,
+		Nodes:       nodes(tonChain.URL),
+	}, relay.ChainOpts{
+		Logger:   lggr,
+		KeyStore: keystore,
+		DS:       ds,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = tonRelayChain.Close() })
+	return tonRelayChain, tonChain
+}
+
+func TestClientRotation(t *testing.T) {
+	var initiallyHealthyRPC, initiallyDisconnectedRPC *proxy.Proxy
+
+	tonChain, _ := setupChain(t, nil, func(chainURL string) config.Nodes {
+		initiallyHealthyRPC = proxy.New(t, chainURL, proxy.BehaviourEnabled)
+		initiallyDisconnectedRPC = proxy.New(t, chainURL, proxy.BehaviourDisconnected)
+
+		return config.Nodes{
+			{
+				Name: new("initially-healthy-rpc"),
+				URL:  commonconfig.MustParseURL(initiallyHealthyRPC.URL()),
+			},
+			{
+				Name: new("initially-disconnected-rpc"),
+				URL:  commonconfig.MustParseURL(initiallyDisconnectedRPC.URL()),
+			},
+		}
+	})
+
+	// Should give us a client based on the healthy RPC (rpcA)
+	// wait for the initial client to be created
+	txmClientProvider := func(ctx context.Context) (ton.APIClientWrapped, error) {
+		signed, err := tonChain.TxManager().GetClient(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return signed.Client, nil
+	}
+
+	txmResolvesHealthyClient := getClient(t, txmClientProvider, requireHealthyClient)
+	require.Eventually(t, txmResolvesHealthyClient, 5*time.Second, 100*time.Millisecond)
+	// Once we get a healthy client for the first time, we should get it every time. Checking multiple times due to round robin.
+	requireAlways(t, txmResolvesHealthyClient, 5*time.Second, 100*time.Millisecond)
+
+	// Disable initiallyHealthyRPC and expect the client to become unhealthy
+	initiallyHealthyRPC.Close()
+	require.Eventually(t, getClient(t, tonChain.GetClient, requireUnhealthyClient), 5*time.Second, 100*time.Millisecond)
+
+	// Now enable initiallyDisconnectedRPC which should cause the relay to switch to initiallyDisconnectedRPC
+	initiallyDisconnectedRPC.SetBehaviour(proxy.BehaviourEnabled)
+
+	time.Sleep(ClientTTL) // Wait for the cached client to expire, which should cause the relay to switch to initiallyDisconnectedRPC
+
+	// relay.Chain gives us a client connected to initiallyDisconnectedRPC after cached client expires
+	require.Eventually(t, getClient(t, tonChain.GetClient, requireHealthyClient), 5*time.Second, 100*time.Millisecond)
+	requireAlways(t, getClient(t, tonChain.GetClient, requireHealthyClient), 5*time.Second, 100*time.Millisecond)
+
+	// TXM should have also switched to initiallyDisconnectedRPC
+	requireAlways(t, txmResolvesHealthyClient, 5*time.Second, 100*time.Millisecond)
+}
+
+func getClient(
+	t *testing.T,
+	getClient func(ctx context.Context) (ton.APIClientWrapped, error),
+	clientAssertions ...func(t *testing.T, client ton.APIClientWrapped) bool,
+) func() bool {
+	return func() bool {
+		var client ton.APIClientWrapped
+		var err error
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		client, err = getClient(ctx)
+		defer cancel()
+		if err != nil {
+			t.Logf("Error getting client: %v", err)
+			return false
+		}
+		for _, assertion := range clientAssertions {
+			if !assertion(t, client) {
+				return false
+			}
+		}
+		return true
+	}
+}
+
+func requireHealthyClient(t *testing.T, client ton.APIClientWrapped) bool {
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	_, err := client.CurrentMasterchainInfo(ctx)
+	if err != nil {
+		t.Logf("Error calling CurrentMasterchainInfo: %v", err)
+		return false
+	}
+	return true
+}
+
+func requireUnhealthyClient(t *testing.T, client ton.APIClientWrapped) bool {
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	_, err := client.CurrentMasterchainInfo(ctx)
+	if err == nil {
+		t.Logf("Expected error calling CurrentMasterchainInfo")
+		return false
+	}
+	return true
+}
+
+func requireAlways(t *testing.T, condition func() bool, waitFor time.Duration, tick time.Duration) {
+	timeout := time.After(waitFor)
+	ticker := time.NewTicker(tick)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-timeout:
+			return
+		case <-ticker.C:
+			require.True(t, condition(), "Condition not satisfied")
+		}
+	}
+}

--- a/integration-tests/testutils/proxy/proxy.go
+++ b/integration-tests/testutils/proxy/proxy.go
@@ -1,0 +1,237 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+)
+
+type Proxy struct {
+	lggr      logger.Logger
+	url       string
+	target    string
+	ln        net.Listener
+	behaviour Behaviour
+	mu        sync.Mutex
+	// serverConns is a set of active connections that are being proxied. We keep track of them so we can close them when the proxy is closed.
+	serverConns  map[net.Conn]struct{}
+	stalledConns map[net.Conn]context.CancelFunc
+}
+
+type stalledConn struct {
+	conn   net.Conn
+	cancel context.CancelFunc
+}
+
+type Behaviour int
+
+const (
+	BehaviourEnabled Behaviour = iota
+	BehaviourStall
+	BehaviourDisconnected
+)
+
+// New creates a new Proxy and starts it.
+//
+// It listens on a random local port and proxies connections to the given liteserver URL.
+//
+// The proxy can be configured to behave in different ways (enabled, stall, or disconnected) to simulate different network conditions.
+func New(t *testing.T, rawURL string, behaviour Behaviour) *Proxy {
+	t.Helper()
+
+	publicKey, hostPort, err := splitLiteserverURL(rawURL)
+	require.NoError(t, err)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	proxy := &Proxy{
+		lggr:         logger.Named(logger.Test(t), "proxy"),
+		url:          fmt.Sprintf("liteserver://%s@%s", publicKey, ln.Addr().String()),
+		target:       hostPort,
+		ln:           ln,
+		behaviour:    behaviour,
+		serverConns:  make(map[net.Conn]struct{}),
+		stalledConns: make(map[net.Conn]context.CancelFunc),
+	}
+	t.Cleanup(proxy.Close)
+
+	go proxy.acceptLoop()
+
+	return proxy
+}
+
+func splitLiteserverURL(rawURL string) (publicKey string, hostPort string, err error) {
+	const prefix = "liteserver://"
+	trimmedURL := strings.TrimPrefix(rawURL, prefix)
+	if trimmedURL == rawURL {
+		return "", "", fmt.Errorf("invalid liteserver URL %q: missing %s prefix", rawURL, prefix)
+	}
+
+	publicKey, hostPort, ok := strings.Cut(trimmedURL, "@")
+	if !ok || publicKey == "" || hostPort == "" {
+		return "", "", fmt.Errorf("invalid liteserver URL %q: expected publicKey@host:port", rawURL)
+	}
+
+	return publicKey, hostPort, nil
+}
+
+func (p *Proxy) URL() string {
+	return p.url
+}
+
+func (p *Proxy) SetBehaviour(behaviour Behaviour) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.behaviour = behaviour
+}
+
+// Close closes the proxy and all active connections to it (including listener).
+func (p *Proxy) Close() {
+	p.mu.Lock()
+	err := p.ln.Close()
+	if err != nil {
+		p.lggr.Errorf("Error closing listener: %v", err)
+	}
+	serverConns, stalledConns := p.drainConnectionsLocked()
+	p.mu.Unlock()
+
+	closeConnections(serverConns, stalledConns)
+}
+
+// DropConnections closes all active connections to the proxy. Useful for simulating a network failure or server going down.
+func (p *Proxy) DropConnections() {
+	p.mu.Lock()
+	serverConns, stalledConns := p.drainConnectionsLocked()
+	p.mu.Unlock()
+
+	closeConnections(serverConns, stalledConns)
+}
+
+func (p *Proxy) acceptLoop() {
+	for {
+		clientConn, err := p.ln.Accept()
+		if err != nil {
+			return
+		}
+
+		var (
+			ctx    context.Context
+			cancel context.CancelFunc
+		)
+		p.mu.Lock()
+		behaviour := p.behaviour
+		switch behaviour {
+		case BehaviourEnabled:
+			p.serverConns[clientConn] = struct{}{}
+		case BehaviourStall:
+			ctx, cancel = context.WithCancel(context.Background()) //nolint:gosec // cancel is stored in p.stalledConns and called when the connection is closed
+			p.stalledConns[clientConn] = cancel
+		default:
+		}
+		p.mu.Unlock()
+
+		switch behaviour {
+		case BehaviourEnabled:
+			go p.handle(clientConn)
+		case BehaviourDisconnected:
+			closeWithReset(clientConn)
+			continue
+		case BehaviourStall:
+			go p.handleStall(ctx, clientConn)
+		}
+	}
+}
+
+func (p *Proxy) handle(clientConn net.Conn) {
+	defer p.forgetAndClose(clientConn)
+
+	serverConn, err := net.Dial("tcp", p.target)
+	if err != nil {
+		return
+	}
+	defer p.forgetAndClose(serverConn)
+
+	p.mu.Lock()
+	p.serverConns[serverConn] = struct{}{}
+	p.mu.Unlock()
+
+	done := make(chan struct{}, 2)
+	go proxyCopy(done, clientConn, serverConn)
+	go proxyCopy(done, serverConn, clientConn)
+	<-done
+}
+
+// handleStall simulates an unhealthy RPC that completes the TCP connect and
+// accepts the client's ADNL handshake bytes but never sends anything back, so
+// the handshake never finishes. We drain (and discard) whatever the client
+// sends so its writes never block, but we never reply. This wedges
+// liteclient.AddConnection on its post-handshake `select` waiting for the
+// connection result, which only unblocks once the caller's context is
+// cancelled.
+func (p *Proxy) handleStall(ctx context.Context, clientConn net.Conn) {
+	defer p.forgetAndClose(clientConn)
+
+	// Drain anything the client sends without ever responding.
+	go func() { _, _ = io.Copy(io.Discard, clientConn) }()
+
+	<-ctx.Done()
+}
+
+func (p *Proxy) forgetAndClose(conn net.Conn) {
+	p.mu.Lock()
+	delete(p.serverConns, conn)
+	if cancel, ok := p.stalledConns[conn]; ok {
+		cancel()
+		delete(p.stalledConns, conn)
+	}
+	p.mu.Unlock()
+	closeWithReset(conn)
+}
+
+func (p *Proxy) drainConnectionsLocked() ([]net.Conn, []stalledConn) {
+	serverConns := make([]net.Conn, 0, len(p.serverConns))
+	for conn := range p.serverConns {
+		serverConns = append(serverConns, conn)
+	}
+
+	stalledConns := make([]stalledConn, 0, len(p.stalledConns))
+	for conn, cancel := range p.stalledConns {
+		stalledConns = append(stalledConns, stalledConn{conn: conn, cancel: cancel})
+	}
+
+	p.serverConns = make(map[net.Conn]struct{})
+	p.stalledConns = make(map[net.Conn]context.CancelFunc)
+
+	return serverConns, stalledConns
+}
+
+func closeConnections(serverConns []net.Conn, stalledConns []stalledConn) {
+	for _, conn := range serverConns {
+		closeWithReset(conn)
+	}
+	for _, stalledConn := range stalledConns {
+		stalledConn.cancel()
+		closeWithReset(stalledConn.conn)
+	}
+}
+
+func closeWithReset(conn net.Conn) {
+	if tcpConn, ok := conn.(*net.TCPConn); ok {
+		_ = tcpConn.SetLinger(0)
+	}
+	_ = conn.Close()
+}
+
+func proxyCopy(done chan<- struct{}, dst io.Writer, src io.Reader) {
+	_, _ = io.Copy(dst, src)
+	done <- struct{}{}
+}

--- a/integration-tests/testutils/proxy/proxy.go
+++ b/integration-tests/testutils/proxy/proxy.go
@@ -8,14 +8,18 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
 
+const dialTimeout = time.Second
+
 type Proxy struct {
 	lggr      logger.Logger
+	cancel    context.CancelFunc
 	url       string
 	target    string
 	ln        net.Listener
@@ -24,11 +28,6 @@ type Proxy struct {
 	// serverConns is a set of active connections that are being proxied. We keep track of them so we can close them when the proxy is closed.
 	serverConns  map[net.Conn]struct{}
 	stalledConns map[net.Conn]context.CancelFunc
-}
-
-type stalledConn struct {
-	conn   net.Conn
-	cancel context.CancelFunc
 }
 
 type Behaviour int
@@ -50,11 +49,14 @@ func New(t *testing.T, rawURL string, behaviour Behaviour) *Proxy {
 	publicKey, hostPort, err := splitLiteserverURL(rawURL)
 	require.NoError(t, err)
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	ctx, cancel := context.WithCancel(t.Context())
+	var listenConfig net.ListenConfig
+	ln, err := listenConfig.Listen(ctx, "tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
 	proxy := &Proxy{
 		lggr:         logger.Named(logger.Test(t), "proxy"),
+		cancel:       cancel,
 		url:          fmt.Sprintf("liteserver://%s@%s", publicKey, ln.Addr().String()),
 		target:       hostPort,
 		ln:           ln,
@@ -64,7 +66,7 @@ func New(t *testing.T, rawURL string, behaviour Behaviour) *Proxy {
 	}
 	t.Cleanup(proxy.Close)
 
-	go proxy.acceptLoop()
+	go proxy.acceptLoop(ctx)
 
 	return proxy
 }
@@ -96,6 +98,8 @@ func (p *Proxy) SetBehaviour(behaviour Behaviour) {
 
 // Close closes the proxy and all active connections to it (including listener).
 func (p *Proxy) Close() {
+	p.cancel()
+
 	p.mu.Lock()
 	err := p.ln.Close()
 	if err != nil {
@@ -116,7 +120,7 @@ func (p *Proxy) DropConnections() {
 	closeConnections(serverConns, stalledConns)
 }
 
-func (p *Proxy) acceptLoop() {
+func (p *Proxy) acceptLoop(ctx context.Context) {
 	for {
 		clientConn, err := p.ln.Accept()
 		if err != nil {
@@ -124,8 +128,8 @@ func (p *Proxy) acceptLoop() {
 		}
 
 		var (
-			ctx    context.Context
-			cancel context.CancelFunc
+			connCtx    context.Context
+			connCancel context.CancelFunc
 		)
 		p.mu.Lock()
 		behaviour := p.behaviour
@@ -133,28 +137,32 @@ func (p *Proxy) acceptLoop() {
 		case BehaviourEnabled:
 			p.serverConns[clientConn] = struct{}{}
 		case BehaviourStall:
-			ctx, cancel = context.WithCancel(context.Background()) //nolint:gosec // cancel is stored in p.stalledConns and called when the connection is closed
-			p.stalledConns[clientConn] = cancel
+			connCtx, connCancel = context.WithCancel(ctx) //nolint:gosec // connCancel is stored in p.stalledConns and called when the connection is closed
+			p.stalledConns[clientConn] = connCancel
 		default:
 		}
 		p.mu.Unlock()
 
 		switch behaviour {
 		case BehaviourEnabled:
-			go p.handle(clientConn)
+			go p.handle(ctx, clientConn)
 		case BehaviourDisconnected:
 			closeWithReset(clientConn)
 			continue
 		case BehaviourStall:
-			go p.handleStall(ctx, clientConn)
+			go p.handleStall(connCtx, clientConn)
 		}
 	}
 }
 
-func (p *Proxy) handle(clientConn net.Conn) {
+func (p *Proxy) handle(ctx context.Context, clientConn net.Conn) {
 	defer p.forgetAndClose(clientConn)
 
-	serverConn, err := net.Dial("tcp", p.target)
+	var dialer net.Dialer
+	dialCtx, cancel := context.WithTimeout(ctx, dialTimeout)
+	defer cancel()
+
+	serverConn, err := dialer.DialContext(dialCtx, "tcp", p.target)
 	if err != nil {
 		return
 	}
@@ -197,30 +205,23 @@ func (p *Proxy) forgetAndClose(conn net.Conn) {
 	closeWithReset(conn)
 }
 
-func (p *Proxy) drainConnectionsLocked() ([]net.Conn, []stalledConn) {
-	serverConns := make([]net.Conn, 0, len(p.serverConns))
-	for conn := range p.serverConns {
-		serverConns = append(serverConns, conn)
-	}
-
-	stalledConns := make([]stalledConn, 0, len(p.stalledConns))
-	for conn, cancel := range p.stalledConns {
-		stalledConns = append(stalledConns, stalledConn{conn: conn, cancel: cancel})
-	}
+func (p *Proxy) drainConnectionsLocked() (server map[net.Conn]struct{}, stalled map[net.Conn]context.CancelFunc) {
+	server = p.serverConns
+	stalled = p.stalledConns
 
 	p.serverConns = make(map[net.Conn]struct{})
 	p.stalledConns = make(map[net.Conn]context.CancelFunc)
 
-	return serverConns, stalledConns
+	return
 }
 
-func closeConnections(serverConns []net.Conn, stalledConns []stalledConn) {
-	for _, conn := range serverConns {
+func closeConnections(serverConns map[net.Conn]struct{}, stalledConns map[net.Conn]context.CancelFunc) {
+	for conn := range serverConns {
 		closeWithReset(conn)
 	}
-	for _, stalledConn := range stalledConns {
-		stalledConn.cancel()
-		closeWithReset(stalledConn.conn)
+	for stalledConn, cancel := range stalledConns {
+		cancel()
+		closeWithReset(stalledConn)
 	}
 }
 

--- a/pkg/ccip/chainaccessor/ton_accessor.go
+++ b/pkg/ccip/chainaccessor/ton_accessor.go
@@ -420,7 +420,7 @@ func (a *TONAccessor) GetExpectedNextSequenceNumber(ctx context.Context, dest cc
 	if err != nil {
 		return 0, fmt.Errorf("failed to get TON client: %w", err)
 	}
-	result, err := client.RunGetMethod(ctx, block, addr, "expectedNextSequenceNumber", uint64(dest))
+	result, err := client.WaitForBlock(block.SeqNo).RunGetMethod(ctx, block, addr, "expectedNextSequenceNumber", uint64(dest)) // TODO refactor to use tvm.CallGetter
 	if err != nil {
 		return 0, err
 	}
@@ -857,7 +857,7 @@ func (a *TONAccessor) GetLatestPriceSeqNr(ctx context.Context) (ccipocr3.SeqNum,
 	if err != nil {
 		return 0, fmt.Errorf("failed to get TON client: %w", err)
 	}
-	result, err := client.RunGetMethod(ctx, block, addr, "latestPriceSequenceNumber")
+	result, err := client.WaitForBlock(block.SeqNo).RunGetMethod(ctx, block, addr, "latestPriceSequenceNumber") // TODO refactor to use tvm.CallGetter
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,7 +19,7 @@ var DefaultConfigSet = Chain{
 	TransactionManager:  &txm.DefaultConfigSet,
 	LogPoller:           &logpoller.DefaultConfigSet,
 	ContractTransmitter: &ocr.DefaultConfigSet,
-	ClientTTL:           10 * time.Minute,
+	ClientTTL:           2 * time.Minute,
 }
 
 type Chain struct {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -52,5 +52,5 @@ func TestDefaultConfigSet(t *testing.T) {
 	require.NotNil(t, DefaultConfigSet.TransactionManager)
 	require.NotNil(t, DefaultConfigSet.LogPoller)
 	require.NotNil(t, DefaultConfigSet.ContractTransmitter)
-	assert.Equal(t, 10*time.Minute, DefaultConfigSet.ClientTTL)
+	assert.Equal(t, 2*time.Minute, DefaultConfigSet.ClientTTL)
 }

--- a/pkg/logpoller/block.go
+++ b/pkg/logpoller/block.go
@@ -105,7 +105,8 @@ func (lp *service) lookupBlock(ctx context.Context, seqNo uint32, currentMasterc
 	if err != nil {
 		return nil, fmt.Errorf("failed to get client: %w", err)
 	}
-	return client.LookupBlock(ctx, currentMasterchainBlock.Workchain, currentMasterchainBlock.Shard, seqNo)
+	// TBD do we need to use this seqNo or currentMasterchainBlock.SeqNo?
+	return client.WaitForBlock(seqNo).LookupBlock(ctx, currentMasterchainBlock.Workchain, currentMasterchainBlock.Shard, seqNo)
 }
 
 // resolvePreviousBlock determines the previous block reference based on the last processed sequence number
@@ -183,6 +184,7 @@ func (lp *service) fetchMCBlockSeqNo(ctx context.Context, shardBlock *ton.BlockI
 	}
 
 	var resp tl.Serializable
+	// TBD do we need to call .WaitForBlock(shardBlock.SeqNo) here?
 	err = client.Client().QueryLiteserver(ctx, ton.GetShardBlockProof{
 		ID: shardBlock,
 	}, &resp)

--- a/pkg/logpoller/block.go
+++ b/pkg/logpoller/block.go
@@ -105,8 +105,11 @@ func (lp *service) lookupBlock(ctx context.Context, seqNo uint32, currentMasterc
 	if err != nil {
 		return nil, fmt.Errorf("failed to get client: %w", err)
 	}
-	// TBD do we need to use this seqNo or currentMasterchainBlock.SeqNo?
-	return client.WaitForBlock(seqNo).LookupBlock(ctx, currentMasterchainBlock.Workchain, currentMasterchainBlock.Shard, seqNo)
+	block, err := client.WaitForBlock(seqNo).LookupBlock(ctx, currentMasterchainBlock.Workchain, currentMasterchainBlock.Shard, seqNo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to lookup block %d: %w", seqNo, err)
+	}
+	return block, nil
 }
 
 // resolvePreviousBlock determines the previous block reference based on the last processed sequence number

--- a/pkg/logpoller/block.go
+++ b/pkg/logpoller/block.go
@@ -187,7 +187,6 @@ func (lp *service) fetchMCBlockSeqNo(ctx context.Context, shardBlock *ton.BlockI
 	}
 
 	var resp tl.Serializable
-	// TBD do we need to call .WaitForBlock(shardBlock.SeqNo) here?
 	err = client.Client().QueryLiteserver(ctx, ton.GetShardBlockProof{
 		ID: shardBlock,
 	}, &resp)

--- a/pkg/logpoller/block_test.go
+++ b/pkg/logpoller/block_test.go
@@ -42,6 +42,10 @@ func (m *mockAPIClient) Client() ton.LiteClient {
 	return m.liteClient
 }
 
+func (m *mockAPIClient) WaitForBlock(seqno uint32) ton.APIClientWrapped {
+	return m
+}
+
 // mockLiteClient mocks the LiteClient interface for testing liteserver queries
 type mockLiteClient struct {
 	ton.LiteClient

--- a/pkg/logpoller/loader/loader.go
+++ b/pkg/logpoller/loader/loader.go
@@ -140,7 +140,7 @@ func (l *rawTxLoader) GetTransactionLTBounds(ctx context.Context, blockRange *mo
 	case blockRange.Prev == nil:
 		startLT = 0
 	case blockRange.FromSeqNo() > 0:
-		accPrev, accErr := client.GetAccount(ctx, blockRange.Prev, addr)
+		accPrev, accErr := client.WaitForBlock(blockRange.Prev.SeqNo).GetAccount(ctx, blockRange.Prev, addr)
 		if accErr != nil {
 			startLT = 0 // account didn't exist before this range
 		} else {
@@ -221,6 +221,7 @@ func (l *rawTxLoader) listTransactionsWithBlock(ctx context.Context, addr *addre
 	if cerr != nil {
 		return nil, nil, fmt.Errorf("failed to get client: %w", cerr)
 	}
+	// TBD do we need to call .WaitForBlock(seqNum?) here?
 	err := client.Client().QueryLiteserver(ctx, ton.GetTransactions{
 		Limit: int32(limit),
 		AccID: &ton.AccountID{

--- a/pkg/logpoller/loader/loader.go
+++ b/pkg/logpoller/loader/loader.go
@@ -67,7 +67,7 @@ func (l *rawTxLoader) LoadTxsForAddress(ctx context.Context, blockRange *models.
 	curLT, curHash := endLT, endHash
 
 	for {
-		batch, batchBlocks, err := l.listTransactionsWithBlock(ctx, addr, pageSize, curLT, curHash)
+		batch, batchBlocks, err := l.listTransactionsWithBlock(ctx, addr, pageSize, curLT, blockRange.ToSeqNo(), curHash)
 		if errors.Is(err, ton.ErrNoTransactionsWereFound) || len(batch) == 0 {
 			// no more transactions to process
 			break
@@ -205,7 +205,7 @@ func (l *rawTxLoader) GetTxsForAddress(ctx context.Context, blockRange *models.B
 // It returns a list of transactions, a list of corresponding block IDs, and an error if one occurs.
 // ListTransactions - returns list of transactions before (including) passed lt and hash, the oldest one is first in result slice
 // Transactions will be verified to match final tx hash, which should be taken from proved account state, then it is safe.
-func (l *rawTxLoader) listTransactionsWithBlock(ctx context.Context, addr *address.Address, limit uint32, lt uint64, txHash []byte) ([]*tlb.Transaction, []*ton.BlockIDExt, error) {
+func (l *rawTxLoader) listTransactionsWithBlock(ctx context.Context, addr *address.Address, limit uint32, lt uint64, seqNo uint32, txHash []byte) ([]*tlb.Transaction, []*ton.BlockIDExt, error) {
 	// unlikely to have overflow, but just for safety
 	if limit > math.MaxInt32 {
 		return nil, nil, fmt.Errorf("limit %d exceeds maximum int32 value", limit)
@@ -221,8 +221,7 @@ func (l *rawTxLoader) listTransactionsWithBlock(ctx context.Context, addr *addre
 	if cerr != nil {
 		return nil, nil, fmt.Errorf("failed to get client: %w", cerr)
 	}
-	// TBD do we need to call .WaitForBlock(seqNum?) here?
-	err := client.Client().QueryLiteserver(ctx, ton.GetTransactions{
+	err := client.WaitForBlock(seqNo).Client().QueryLiteserver(ctx, ton.GetTransactions{
 		Limit: int32(limit),
 		AccID: &ton.AccountID{
 			Workchain: addr.Workchain(),

--- a/pkg/relay/chain.go
+++ b/pkg/relay/chain.go
@@ -137,25 +137,17 @@ func newChain(cfg *config.TOMLConfig, loopKs loop.Keystore, lggr logger.Logger, 
 	if err != nil {
 		return nil, fmt.Errorf("failed to create TON TXM for chain ID %s: %w", cfg.ChainID, err)
 	}
-
-	clientProvider := func(ctx context.Context) (ton.APIClientWrapped, error) {
-		signedClient, cerr := signedClientProvider(ctx)
-		if cerr != nil {
-			return nil, cerr
-		}
-		return signedClient.Client, nil
-	}
 	lggr.Infow("Creating new chain", "chainID", ch.ID())
 
 	orm := lppgstore.NewORM(ch.ID(), ds, lggr)
 	lgOpts := &logpoller.ServiceOptions{
 		Config:      *ch.cfg.LogPollerConfig(), // get LogPoller configuration from chain config
-		TxLoader:    txloader.New(lggr, clientProvider),
+		TxLoader:    txloader.New(lggr, ch.GetClient),
 		FilterStore: lppgstore.NewFilterStore(ch.ID(), orm, lggr),
 		LogStore:    lppgstore.NewLogStore(ch.ID(), orm, lggr),
 	}
 
-	ch.lp, err = logpoller.NewService(lggr, ch.ID(), clientProvider, lgOpts)
+	ch.lp, err = logpoller.NewService(lggr, ch.ID(), ch.GetClient, lgOpts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create logpoller service: %w", err)
 	}

--- a/pkg/relay/chain.go
+++ b/pkg/relay/chain.go
@@ -46,6 +46,8 @@ import (
 const (
 	balancePollPeriod          = 1 * time.Minute
 	defaultTONClientRetryCount = 5
+	// Max time stablishing a connection to a TON node before giving up. This is used when creating a new connection pool.
+	ConnectionTimeout = 1 * time.Second
 )
 
 type Chain interface {
@@ -466,7 +468,9 @@ func (c *chain) getOrCreatePool(ctx context.Context, nodeIndex int) (*liteclient
 	}
 
 	liteServerURL := c.cfg.Nodes[nodeIndex].URL.String()
-	pool, err := tonchain.CreateLiteserverConnectionPool(ctx, liteServerURL)
+	ctxTimeout, cancel := context.WithTimeout(ctx, ConnectionTimeout)
+	defer cancel()
+	pool, err := tonchain.CreateLiteserverConnectionPool(ctxTimeout, liteServerURL)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/relay/chain.go
+++ b/pkg/relay/chain.go
@@ -116,7 +116,7 @@ func newChain(cfg *config.TOMLConfig, loopKs loop.Keystore, lggr logger.Logger, 
 	}
 
 	// TODO(@jadepark-dev): TXM technically doesn't need SignedAPIClient, revisit to refactor
-	signedClientProvider := commonutils.NewLazyLoadCtx(func(ctx context.Context) (tracetracking.SignedAPIClient, error) {
+	signedClientProvider := func(ctx context.Context) (tracetracking.SignedAPIClient, error) {
 		tonClient, err1 := ch.GetClient(ctx)
 		if err1 != nil {
 			return tracetracking.SignedAPIClient{}, fmt.Errorf("failed to create TON client for chain ID %s: %w", cfg.ChainID, err1)
@@ -131,15 +131,15 @@ func newChain(cfg *config.TOMLConfig, loopKs loop.Keystore, lggr logger.Logger, 
 			Client: tonClient,
 			Wallet: *signerWallet,
 		}, nil
-	})
+	}
 
-	ch.txm, err = txm.New(lggr, ch.id, loopKs, signedClientProvider.Get, *ch.cfg.TxManager())
+	ch.txm, err = txm.New(lggr, ch.id, loopKs, signedClientProvider, *ch.cfg.TxManager())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create TON TXM for chain ID %s: %w", cfg.ChainID, err)
 	}
 
 	clientProvider := func(ctx context.Context) (ton.APIClientWrapped, error) {
-		signedClient, cerr := signedClientProvider.Get(ctx)
+		signedClient, cerr := signedClientProvider(ctx)
 		if cerr != nil {
 			return nil, cerr
 		}

--- a/pkg/relay/chain.go
+++ b/pkg/relay/chain.go
@@ -245,7 +245,7 @@ func (c *chain) LatestHead(ctx context.Context) (commontypes.Head, error) {
 	}
 
 	// Load the full block to get timestamp and hash
-	block, err := client.GetBlockData(ctx, blockID)
+	block, err := client.WaitForBlock(blockID.SeqNo).GetBlockData(ctx, blockID)
 	if err != nil {
 		return commontypes.Head{}, fmt.Errorf("failed to get block data: %w", err)
 	}

--- a/pkg/relay/chain.go
+++ b/pkg/relay/chain.go
@@ -106,6 +106,14 @@ func newChain(cfg *config.TOMLConfig, loopKs loop.Keystore, lggr logger.Logger, 
 		return nil, fmt.Errorf("invalid chain ID %s: could not parse as an integer: %w", cfg.ChainID, err)
 	}
 
+	// Randomize node order to avoid always hitting the same node first
+	nodes := make([]*config.Node, len(cfg.Nodes))
+	indexes := rand.Perm(len(nodes))
+	for i, idx := range indexes {
+		nodes[i] = cfg.Nodes[idx]
+	}
+	cfg.Nodes = nodes
+
 	ch := &chain{
 		id:          cfg.ChainID,
 		cfg:         cfg,
@@ -341,11 +349,7 @@ func (c *chain) GetClient(ctx context.Context) (ton.APIClientWrapped, error) {
 		return nil, errors.New("no nodes available")
 	}
 
-	indexes := rand.Perm(len(nodes))
-
-	for _, i := range indexes {
-		node := nodes[i]
-
+	for i, node := range nodes {
 		// Check cache
 		c.cacheMu.RLock()
 		entry, ok := c.clientCache[i]

--- a/pkg/relay/chain.go
+++ b/pkg/relay/chain.go
@@ -26,7 +26,6 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	commontypes "github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
-	commonutils "github.com/smartcontractkit/chainlink-common/pkg/utils"
 
 	chainsel "github.com/smartcontractkit/chain-selectors"
 
@@ -76,7 +75,6 @@ type cachedClient struct {
 type chain struct {
 	commontypes.UnimplementedChainService
 	services.StateMachine
-	starter commonutils.StartStopOnce
 
 	id   string
 	cfg  *config.TOMLConfig
@@ -194,7 +192,7 @@ func (c *chain) Name() string {
 }
 
 func (c *chain) Start(ctx context.Context) error {
-	return c.starter.StartOnce("Chain", func() error {
+	return c.StartOnce("Chain", func() error {
 		c.lggr.Debug("Starting txm, log poller, and balance monitor")
 		var ms services.MultiStart
 
@@ -212,7 +210,7 @@ func (c *chain) Start(ctx context.Context) error {
 }
 
 func (c *chain) Close() error {
-	return c.starter.StopOnce("Chain", func() error {
+	return c.StopOnce("Chain", func() error {
 		c.lggr.Debug("Stopping txm, log poller, and balance monitor")
 		err := services.CloseAll(c.txm, c.lp, c.bm)
 
@@ -231,11 +229,11 @@ func (c *chain) Close() error {
 }
 
 func (c *chain) Ready() error {
-	return errors.Join(c.starter.Ready(), c.txm.Ready())
+	return errors.Join(c.StateMachine.Ready(), c.txm.Ready())
 }
 
 func (c *chain) HealthReport() map[string]error {
-	report := map[string]error{c.Name(): c.starter.Healthy()}
+	report := map[string]error{c.Name(): c.Healthy()}
 	services.CopyHealth(report, c.txm.HealthReport())
 	services.CopyHealth(report, c.lp.HealthReport())
 	services.CopyHealth(report, c.bm.HealthReport())

--- a/pkg/relay/monitor/balance.go
+++ b/pkg/relay/monitor/balance.go
@@ -187,7 +187,7 @@ func GetAccountBalance(ctx context.Context, client ton.APIClientWrapped, addrStr
 		return -1, fmt.Errorf("failed to parse address [%s]: %w", addrString, err)
 	}
 
-	acc, err := client.GetAccount(ctx, block, addr)
+	acc, err := client.WaitForBlock(block.SeqNo).GetAccount(ctx, block, addr)
 	if err != nil {
 		return -1, fmt.Errorf("failed to get account: %w", err)
 	}

--- a/pkg/ton/tvm/getter.go
+++ b/pkg/ton/tvm/getter.go
@@ -181,7 +181,7 @@ func CallGetter[A any, R any](
 	}
 
 	if len(input) == 0 {
-		result, err := client.RunGetMethod(ctx, block, contractAddr, getter.Name)
+		result, err := client.WaitForBlock(block.SeqNo).RunGetMethod(ctx, block, contractAddr, getter.Name)
 		if err != nil {
 			return zero, fmt.Errorf("tvm: failed to run get method %q: %w", getter.Name, err)
 		}

--- a/pkg/txm/txm.go
+++ b/pkg/txm/txm.go
@@ -172,7 +172,7 @@ func (t *Txm) Enqueue(request Request) error {
 		if err != nil {
 			return fmt.Errorf("RPC error: failed to get current masterchain info: %w", err)
 		}
-		transmitterAccount, err := client.Client.GetAccount(ctx, block, client.Wallet.WalletAddress())
+		transmitterAccount, err := client.Client.WaitForBlock(block.SeqNo).GetAccount(ctx, block, client.Wallet.WalletAddress())
 		if err != nil {
 			return fmt.Errorf("RPC error: failed to get transmitter account info: %w", err)
 		}

--- a/staging-monitor/lib/ton/client.go
+++ b/staging-monitor/lib/ton/client.go
@@ -18,6 +18,7 @@ import (
 	"github.com/smartcontractkit/chainlink-ton/pkg/ton/tvm"
 
 	chainsel "github.com/smartcontractkit/chain-selectors"
+
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
 	"github.com/smartcontractkit/chainlink-ton/deployment/testadapter"
@@ -312,7 +313,7 @@ func (c *Client) GetBalance(ctx context.Context, addrStr string) (string, error)
 		return "", fmt.Errorf("failed to get masterchain info: %w", err)
 	}
 
-	acc, err := c.client.GetAccount(ctx, mc, addr)
+	acc, err := c.client.WaitForBlock(mc.SeqNo).GetAccount(ctx, mc, addr)
 	if err != nil {
 		return "", fmt.Errorf("failed to get account: %w", err)
 	}


### PR DESCRIPTION
TON LogPoller and TXM could permanently stall after node restart
No context timeout when calling CreateLiteserverConnectionPool / AddConnection 

Once we create a client for LogPoller and TXM it never refreshes
If a RCP goes down, the LogPoller and TXM cannot recover
We should remove the commonutils.NewLazyLoadCtx as GetClient already has caching.

LogPoller is using a signed client when it shouldn’t
Only TXM needs a signed client.